### PR TITLE
✨ feat(ci): Cloudflare Worker クリーンアップ処理の追加と権限見直し

### DIFF
--- a/.github/workflows/be-health_check_ci.yml
+++ b/.github/workflows/be-health_check_ci.yml
@@ -125,7 +125,7 @@ jobs:
         fi
     # --- 【ステップ 4: Workerの削除（クリーンアップ）】 ---
     - name: Delete Preview Worker (Cleanup)
-      if: always() # 後のステップで失敗しても、必ず実行する
+      if: always() # 後のステップで失敗しても、必ず実行する 
       run: |
         set +e
         # ステップ 2 で使用した Worker 名を再構築


### PR DESCRIPTION
## やったこと

- CI実行後に Cloudflare Workers に残存していたプレビュー Worker を確実に削除するクリーンアップロジックを追加しました。
- `wrangler delete` コマンドがエラー終了（Exit Code 1）しても、スクリプトが停止せずにエラーハンドリングを実行できるように、`set +e` を追加しました。
- Cloudflare APIトークンにWorkers KV Storage の Edit 権限を追加しました。

- なぜこのPRが必要なのか
  - CI実行後に Worker が Cloudflare 上に残り続けることで、リソースの浪費や将来的な Worker 名の重複によるデプロイ失敗リスクを抱えていました。
  - 本 PR により、CIが作成した Worker は CI 終了時に必ずクリーンアップされるようになり、CI パイプラインがより安定しました。

## ドキュメント

- (関連するチケットや議論があればここに貼り付け)

## 動作確認
- [ ] 動作検証不要（アプリケーションの変更無し、など）
- [ ] ツールで動作検証できる
- [x] ツールで動作検証できない（動作確認の方法を記載した）

### 動作確認の方法

1.  本 PR ブランチにプッシュし、GitHub Actions の CI を実行します。
2.  `deploy_and_check` ジョブが完了した後、Cloudflare ダッシュボードにてプレビュー Worker (`feature-...-ci-test`) が**存在しない**ことを確認します。
3.  CI ログの `Delete Preview Worker (Cleanup)` ステップが **✅ Successfully deleted Worker** を出力し、ジョブ全体が成功していることを確認します。

## レビュー項目
- [x] `Delete Preview Worker (Cleanup)` ステップのシェルスクリプトのロジックが、期待通りに動作するか。（特に `set +e` と `grep -q "Code: 10090"` のロジック）
- [ ] 誤って本番環境のリソースを削除する可能性がないか。（Worker 名に `-ci-test` を付与し、`--name` で明示しているため、リスクは低い想定です。）
- [ ] 大まかに何をしているかわかるか

### 本PRのスコープ外

- [ ] 特になし

### マージ期日 or 目標（あれば）
- 特になし（そんなに重い内容じゃないので、数日でしれっと入れちゃうかもです）

## 備考
- 特になし
