### PR TITLE
相談一覧を作成日時の降順でデフォルトソートするよう実装

### DIFF
--- a/apps/fumufumu-backend/src/repositories/consultation.repository.ts
+++ b/apps/fumufumu-backend/src/repositories/consultation.repository.ts
@@ -39,6 +39,7 @@ export class ConsultationRepository {
 			where: whereConditions.length > 0 
 				? and(...whereConditions) 
 				: undefined,
+			orderBy: (fields, { desc }) => [desc(fields.createdAt)],
 			with: {
 				author: true,
 			},


### PR DESCRIPTION
## やったこと

- 相談一覧API（GET /api/consultations）のソート順を作成日時の降順に変更

- なぜこのPRが必要なのか
  - 新しい相談を先頭に表示し、ユーザーが最新の相談を見つけやすくするため

## ドキュメント

- なし

## 動作確認

- [x] ツールで動作検証できる

```bash
# サインイン
curl -s -X POST 'http://127.0.0.1:8787/api/auth/signin' \
  -H 'Content-Type: application/json' \
  -d '{"email": "testuser@example.com", "password": "password123"}' \
  --cookie-jar cookie_jar.txt

# 相談一覧取得（created_at降順を確認）
curl -s 'http://127.0.0.1:8787/api/consultations' \
  --cookie cookie_jar.txt | jq '.data[] | {id, created_at}'
```

## レビュー項目

- [ ] Repositoryレイヤーでのソート実装が適切か

### 本PRのスコープ外

- なし

### マージ期日 or 目標（あれば）

- 特になし

## 備考

- Drizzle ORMのRelational Query Builder形式で `orderBy` を実装