### PR TITLE
🩹fix(auth,d1): 認証失敗時のステータスを適正化し、Drizzle Studioとwrangler devのローカルD1参照先を統一

### DIFF
--- a/apps/fumufumu-backend/README.md
+++ b/apps/fumufumu-backend/README.md
@@ -1,5 +1,6 @@
 ## コマンド集
 - ローカル開発起動: `pnpm dev`
+- Drizzle Studio 起動: `pnpm studio`
 - curl http://127.0.0.1:8787/
 - ローカルタグ一覧: `pnpm tags:list`
 - ローカルタグ追加: `pnpm tags:add キャリア 人間関係 技術`
@@ -7,6 +8,7 @@
 
 `pnpm dev` はデフォルトで `wrangler.local.jsonc` を使う。
 必要なら `WRANGLER_DEV_CONFIG` で dev 用 config を上書きできる。
+`pnpm studio` も同じ優先順（`WRANGLER_DEV_CONFIG` → `WRANGLER_D1_CONFIG` → `wrangler.local.jsonc`）でローカルD1を解決する。
 
 ## D1 migration runbook (production)
 

--- a/apps/fumufumu-backend/README.md
+++ b/apps/fumufumu-backend/README.md
@@ -1,8 +1,12 @@
 ## コマンド集
+- ローカル開発起動: `pnpm dev`
 - curl http://127.0.0.1:8787/
 - ローカルタグ一覧: `pnpm tags:list`
 - ローカルタグ追加: `pnpm tags:add キャリア 人間関係 技術`
 - 手動デプロイ: `DEPLOY_APPROVED=1 WRANGLER_DEPLOY_CONFIG=wrangler.local.jsonc pnpm deploy`
+
+`pnpm dev` はデフォルトで `wrangler.local.jsonc` を使う。
+必要なら `WRANGLER_DEV_CONFIG` で dev 用 config を上書きできる。
 
 ## D1 migration runbook (production)
 

--- a/apps/fumufumu-backend/drizzle.config.ts
+++ b/apps/fumufumu-backend/drizzle.config.ts
@@ -2,15 +2,93 @@
 // 🚨 注意: この設定はローカル開発ツール（drizzle-kit）専用であり、
 // Cloudflare WorkersのデプロイやリモートのD1データベースには影響しません。
 
+import { existsSync, readFileSync } from "node:fs";
+import { createHash, createHmac } from "node:crypto";
+import { resolve } from "node:path";
 import { defineConfig } from "drizzle-kit";
 
-const DB_FILE_PATH = './.wrangler/state/v3/d1/miniflare-D1DatabaseObject/390251f9042a6eeca3249468e2dcce0fba1d1e8e4befe411979c8f7b0e66446b.sqlite';
+const D1_LOCAL_DB_DIR = ".wrangler/state/v3/d1/miniflare-D1DatabaseObject";
+const D1_OBJECT_UNIQUE_KEY = "miniflare-D1DatabaseObject";
+const DEFAULT_WRANGLER_CONFIG = "wrangler.local.jsonc";
+
+type WranglerD1Config = {
+  d1_databases?: Array<{
+    binding?: string;
+    database_id?: string;
+  }>;
+};
+
+function stripJsoncComments(raw: string) {
+  return raw
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|\s)\/\/.*$/gm, "")
+    .replace(/,\s*([}\]])/g, "$1");
+}
+
+function getWranglerConfigPath() {
+  const config = process.env.WRANGLER_DEV_CONFIG
+    ?? process.env.WRANGLER_D1_CONFIG
+    ?? DEFAULT_WRANGLER_CONFIG;
+  return resolve(process.cwd(), config);
+}
+
+function readDatabaseIdFromWranglerConfig() {
+  const wranglerConfigPath = getWranglerConfigPath();
+
+  if (!existsSync(wranglerConfigPath)) {
+    throw new Error(
+      `Wrangler config not found: ${wranglerConfigPath}\n` +
+      "Set WRANGLER_DEV_CONFIG or WRANGLER_D1_CONFIG, or create wrangler.local.jsonc.",
+    );
+  }
+
+  const raw = readFileSync(wranglerConfigPath, "utf8");
+  const parsed = JSON.parse(stripJsoncComments(raw)) as WranglerD1Config;
+  const d1 =
+    parsed.d1_databases?.find((db) => db.binding === "DB")
+    ?? parsed.d1_databases?.[0];
+  const databaseId = d1?.database_id;
+
+  if (!databaseId) {
+    throw new Error(
+      `database_id for binding "DB" is missing in ${wranglerConfigPath}`,
+    );
+  }
+
+  if (databaseId.startsWith("YOUR_")) {
+    throw new Error(
+      `database_id in ${wranglerConfigPath} is a placeholder: ${databaseId}`,
+    );
+  }
+
+  return databaseId;
+}
+
+function resolveLocalD1FilePath(databaseId: string) {
+  // MiniflareのD1ファイル名は database_id から Durable Object ID と同じ手順で導出される。
+  const key = createHash("sha256").update(D1_OBJECT_UNIQUE_KEY).digest();
+  const nameHmac = createHmac("sha256", key).update(databaseId).digest().subarray(0, 16);
+  const hmac = createHmac("sha256", key).update(nameHmac).digest().subarray(0, 16);
+  const fileName = `${Buffer.concat([nameHmac, hmac]).toString("hex")}.sqlite`;
+
+  const fullPath = resolve(process.cwd(), D1_LOCAL_DB_DIR, fileName);
+  if (!existsSync(fullPath)) {
+    throw new Error(
+      `Local D1 file not found: ${fullPath}\n` +
+      "Run `pnpm dev` once (or apply local migrations) so the local D1 file is created.",
+    );
+  }
+  return fullPath;
+}
+
+const databaseId = readDatabaseIdFromWranglerConfig();
+const DB_FILE_PATH = resolveLocalD1FilePath(databaseId);
 
 export default defineConfig({
-	dialect: "sqlite",
-	schema: "./src/db/schema",
-	out: "./drizzle",
-	dbCredentials: {
+  dialect: "sqlite",
+  schema: "./src/db/schema",
+  out: "./drizzle",
+  dbCredentials: {
     url: DB_FILE_PATH,
   },
 });

--- a/apps/fumufumu-backend/package.json
+++ b/apps/fumufumu-backend/package.json
@@ -2,7 +2,8 @@
   "name": "@fumufumu/backend",
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev:require-config": "test -f \"${WRANGLER_DEV_CONFIG:-${WRANGLER_D1_CONFIG:-wrangler.local.jsonc}}\" || (echo \"Wrangler dev config not found: ${WRANGLER_DEV_CONFIG:-${WRANGLER_D1_CONFIG:-wrangler.local.jsonc}}\" && exit 1)",
+    "dev": "pnpm dev:require-config && wrangler dev --config \"${WRANGLER_DEV_CONFIG:-${WRANGLER_D1_CONFIG:-wrangler.local.jsonc}}\"",
     "deploy:require-approved": "test \"${DEPLOY_APPROVED:-}\" = \"1\" || (echo \"Set DEPLOY_APPROVED=1 to allow deploy\" && exit 1)",
     "deploy:require-config": "test -f \"${WRANGLER_DEPLOY_CONFIG:-wrangler.local.jsonc}\" || (echo \"Wrangler deploy config not found: ${WRANGLER_DEPLOY_CONFIG:-wrangler.local.jsonc}\" && exit 1)",
     "deploy": "pnpm deploy:require-approved && pnpm deploy:require-config && wrangler deploy --minify --config \"${WRANGLER_DEPLOY_CONFIG:-wrangler.local.jsonc}\"",

--- a/apps/fumufumu-backend/src/routes/auth.routes.ts
+++ b/apps/fumufumu-backend/src/routes/auth.routes.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
 import { users, authMappings } from '../db/schema/user';
+import { authUsers } from '../db/schema/auth';
+import { eq } from 'drizzle-orm';
 
 import { type Env, type Variables } from '../index';
 
@@ -124,11 +126,24 @@ authRouter.post('/signup', async (c) => {
  */
 authRouter.post('/signin', async (c) => {
   const auth = c.get('auth');
+  const db = c.get('db');
   const body = await c.req.json();
   const { email, password } = body;
 
   if (!email || !password) {
     return c.json({ error: 'Email and password are required' }, 400);
+  }
+
+  // Better Authのエラー経路でUnhandled Rejectionが発生するケースを避けるため、
+  // 未登録メールは事前に401で返す（メッセージは汎用化して情報漏洩を避ける）。
+  const existingUser = await db
+    .select({ id: authUsers.id })
+    .from(authUsers)
+    .where(eq(authUsers.email, email))
+    .limit(1);
+
+  if (existingUser.length === 0) {
+    return c.json({ message: 'Invalid email or password' }, 401);
   }
 
   let authResponse: Response;

--- a/apps/fumufumu-backend/src/routes/auth.routes.ts
+++ b/apps/fumufumu-backend/src/routes/auth.routes.ts
@@ -6,6 +6,25 @@ import { type Env, type Variables } from '../index';
 // 認証ルーターのHonoインスタンスを定義
 export const authRouter = new Hono<{ Bindings: Env, Variables: Variables }>();
 
+async function parseAuthResponse(response: Response) {
+  const contentType = response.headers.get('content-type') || '';
+
+  if (contentType.includes('application/json')) {
+    return response.clone().json();
+  }
+
+  const text = await response.clone().text();
+  return text ? { message: text } : {};
+}
+
+function copySetCookieHeader(source: Response, target: Response) {
+  const setCookieHeader = source.headers.get('Set-Cookie');
+
+  if (setCookieHeader) {
+    target.headers.set('Set-Cookie', setCookieHeader);
+  }
+}
+
 /**
  * サインアップ API (POST /api/signup)
  */
@@ -35,7 +54,7 @@ authRouter.post('/signup', async (c) => {
     });
 
     authResponse = betterAuthResponse;
-    authResult = await betterAuthResponse.json();
+    authResult = await parseAuthResponse(betterAuthResponse);
 
   } catch (e) {
     console.error('Sign-up failed:', e);
@@ -44,6 +63,12 @@ authRouter.post('/signup', async (c) => {
       return e;
     }
     return c.json({ error: 'Sign-up failed', details: (e as Error).message }, 400);
+  }
+
+  if (!authResponse.ok) {
+    const errorResponse = c.json(authResult ?? { error: 'Sign-up failed' }, authResponse.status as any);
+    copySetCookieHeader(authResponse, errorResponse);
+    return errorResponse;
   }
 
   const authUserId = authResult.user?.id;
@@ -84,11 +109,9 @@ authRouter.post('/signup', async (c) => {
     app_user_id: appUserId,
   };
   const honoResponse = c.json(responseBody, 200);
-  
-  const setCookieHeader = authResponse.headers.get('Set-Cookie');
-  if (setCookieHeader) {
-    honoResponse.headers.set('Set-Cookie', setCookieHeader);
-  } else {
+
+  copySetCookieHeader(authResponse, honoResponse);
+  if (!authResponse.headers.get('Set-Cookie')) {
     console.warn("WARNING: Set-Cookie header missing from Better Auth response during signup.");
   }
 
@@ -122,7 +145,7 @@ authRouter.post('/signin', async (c) => {
     });
 
     authResponse = betterAuthResponse;
-    authResult = await betterAuthResponse.json();
+    authResult = await parseAuthResponse(betterAuthResponse);
 
   } catch (e) {
     console.error('Sign-in failed:', e);
@@ -130,6 +153,12 @@ authRouter.post('/signin', async (c) => {
       return e;
     }
     return c.json({ error: 'Sign-in failed', details: (e as Error).message }, 401);
+  }
+
+  if (!authResponse.ok) {
+    const errorResponse = c.json(authResult ?? { error: 'Sign-in failed' }, authResponse.status as any);
+    copySetCookieHeader(authResponse, errorResponse);
+    return errorResponse;
   }
 
   const authUserId = authResult.user?.id;
@@ -144,13 +173,8 @@ authRouter.post('/signin', async (c) => {
     auth_user_id: authUserId,
   }, 200);
 
-  // Better AuthのレスポンスからSet-Cookieヘッダーを取得（クッキーをクライアントに設定させる）
-  const setCookieHeader = authResponse.headers.get('Set-Cookie');
-
-  // Set-CookieヘッダーをBetter Authのレスポンスからコピー
-  if (setCookieHeader) {
-    honoResponse.headers.set('Set-Cookie', setCookieHeader);
-  } else {
+  copySetCookieHeader(authResponse, honoResponse);
+  if (!authResponse.headers.get('Set-Cookie')) {
     console.warn("WARNING: Set-Cookie header missing from Better Auth response during signin.");
   }
 

--- a/apps/fumufumu-backend/src/test/auth-flow.test.ts
+++ b/apps/fumufumu-backend/src/test/auth-flow.test.ts
@@ -87,5 +87,23 @@ describe('Integration Tests', () => {
 			const newCookie = signinRes.headers.get('set-cookie');
 			expect(newCookie).toBeTruthy();
 		});
+
+		it('should return a client auth error instead of 500 when the user does not exist', async () => {
+			const signinReq = createApiRequest('/api/auth/signin', 'POST', {
+				body: {
+					email: `missing-${Date.now()}@example.com`,
+					password: testUser.password,
+				},
+			});
+			const signinRes = await app.fetch(signinReq, env);
+
+			expect(signinRes.ok).toBe(false);
+			expect(signinRes.status).toBeGreaterThanOrEqual(400);
+			expect(signinRes.status).toBeLessThan(500);
+			expect(signinRes.headers.get('set-cookie')).toBeFalsy();
+
+			const signinBody = await signinRes.json() as any;
+			expect(signinBody.auth_user_id).toBeUndefined();
+		});
 	});
 });


### PR DESCRIPTION
## やったこと

- Better Auth の `signIn/signUp` で非2xxレスポンスを成功扱いしないように修正し、ステータス/本文をそのまま返すようにした
- `Set-Cookie` 転送処理とレスポンス解析処理を共通化した
- 未登録ユーザーのサインインで 500 にならないことを確認するテストを追加した
- `pnpm dev` が `wrangler.local.jsonc`（または `WRANGLER_DEV_CONFIG` / `WRANGLER_D1_CONFIG`）を使うように統一した
- `drizzle.config.ts` の固定SQLite参照を廃止し、`database_id` から Miniflare のローカルD1ファイル名を導出して接続するように変更した
- README に `pnpm studio` の接続先解決ルールを追記した
- なぜこのPRが必要なのか
  - 認証失敗を 500 と誤判定しており、クライアント側で原因を正しく扱えなかったため
  - Drizzle Studio と API が別DBを参照し、調査時に「StudioにはいるのにAPIではいない」誤認が発生していたため

## ドキュメント

- なし

## 動作確認

- [ ] 動作検証不要（アプリケーションの変更無し、など）
- [ ] ツールで動作検証できる
- [x] ツールで動作検証できない（動作確認の方法を記載した）

ローカルで以下を確認:
1. `pnpm dev` 起動後、未登録メールで `POST /api/auth/signin` を実行すると 500 ではなく 401 を返すこと
2. `pnpm studio` で表示される `auth_users` の内容と、API が参照しているローカルD1の実データが一致すること

## レビュー項目

- [ ] 認証失敗時に Better Auth の非2xxをそのまま返す方針で問題ないか
- [ ] `drizzle.config.ts` の `database_id` からのローカルD1解決ロジック（優先順/エラー文言）が妥当か

### 本PRのスコープ外

- [ ] 本番/リモートD1運用フローの変更
- [ ] 既存 seed スクリプトの接続先統一

### マージ期日 or 目標（あれば）

- 入れちゃいますmm

## 備考

- MiniflareのD1ファイル名規則に合わせて、`database_id` からローカルSQLiteファイル名を導出しています
