### PR TITLE
✨feat(auth): サインアウトAPI追加とユーザーメニューからのサインアウト導線実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Scope
+- This file applies to the entire repository (the directory containing this `AGENTS.md`) and all subdirectories.
+
+## Security and Privacy
+- Never include personal names, usernames, or other personally identifiable strings in assistant output.
+- Never include absolute paths that expose home directory information.
+- In explanations, commit messages, and reviews, use repository-relative paths only.
+- If a tool requires an absolute path internally, do not echo that absolute path back to the user.
+
+## Frontend Rule: Avoid `useEffect`
+- In this repository, do not use `useEffect` by default.
+- Prefer these alternatives first:
+  - Server Components / server-side data fetching
+  - Event handlers (`onClick`, `onChange`, `onBlur`, `onKeyDown`, etc.)
+  - Derived values from props/state
+  - `useMemo` / `useCallback`
+  - `ref`-based handling without global event subscriptions
+  - CSS and framework features
+
+## Allowed Exceptions
+- `useEffect` is allowed only when there is no practical alternative, such as:
+  - Subscribing/unsubscribing browser or external events
+  - Integrating imperative third-party libraries that require lifecycle sync
+  - Cleanup that is necessary to prevent leaks or invalid behavior
+
+## If `useEffect` Is Unavoidable
+- Add a short reason in code comments.
+- Keep dependencies minimal and correct.
+- Do not use `useEffect` for logic that can be handled during render or by event handlers.
+- Do not use client-side `useEffect` for data fetching when server-side fetching is feasible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+## Scope
+- This file applies to the entire repository (the directory containing this `CLAUDE.md`) and all subdirectories.
+
+## Security and Privacy
+- Never include personal names, usernames, or other personally identifiable strings in assistant output.
+- Never include absolute paths that expose home directory information.
+- In explanations, commit messages, and reviews, use repository-relative paths only.
+- If a tool requires an absolute path internally, do not echo that absolute path back to the user.
+
+## Frontend Rule: Avoid `useEffect`
+- In this repository, do not use `useEffect` by default.
+- Prefer these alternatives first:
+  - Server Components / server-side data fetching
+  - Event handlers (`onClick`, `onChange`, `onBlur`, `onKeyDown`, etc.)
+  - Derived values from props/state
+  - `useMemo` / `useCallback`
+  - `ref`-based handling without global event subscriptions
+  - CSS and framework features
+
+## Allowed Exceptions
+- `useEffect` is allowed only when there is no practical alternative, such as:
+  - Subscribing/unsubscribing browser or external events
+  - Integrating imperative third-party libraries that require lifecycle sync
+  - Cleanup that is necessary to prevent leaks or invalid behavior
+
+## If `useEffect` Is Unavoidable
+- Add a short reason in code comments.
+- Keep dependencies minimal and correct.
+- Do not use `useEffect` for logic that can be handled during render or by event handlers.
+- Do not use client-side `useEffect` for data fetching when server-side fetching is feasible.

--- a/apps/fumufumu-backend/src/routes/auth.routes.ts
+++ b/apps/fumufumu-backend/src/routes/auth.routes.ts
@@ -180,3 +180,42 @@ authRouter.post('/signin', async (c) => {
 
   return honoResponse;
 });
+
+/**
+ * サインアウト API (POST /api/signout)
+ */
+authRouter.post('/signout', async (c) => {
+  const auth = c.get('auth');
+
+  let authResponse: Response;
+
+  try {
+    authResponse = await auth.api.signOut({
+      headers: c.req.raw.headers,
+      // クッキーを含むResponseを取得
+      asResponse: true,
+    });
+  } catch (e) {
+    console.error('Sign-out failed:', e);
+    if (e instanceof Response) {
+      return e;
+    }
+    return c.json({ error: 'Sign-out failed', details: (e as Error).message }, 400);
+  }
+
+  const honoResponse = c.json({
+    message: 'Sign out successful.',
+  }, 200);
+
+  // Better AuthのレスポンスからSet-Cookieヘッダーを取得（クッキーをクライアント側で削除させる）
+  const setCookieHeader = authResponse.headers.get('Set-Cookie');
+
+  // Set-CookieヘッダーをBetter Authのレスポンスからコピー
+  if (setCookieHeader) {
+    honoResponse.headers.set('Set-Cookie', setCookieHeader);
+  } else {
+    console.warn("WARNING: Set-Cookie header missing from Better Auth response during signout.");
+  }
+
+  return honoResponse;
+});

--- a/apps/fumufumu-backend/src/test/auth-flow.test.ts
+++ b/apps/fumufumu-backend/src/test/auth-flow.test.ts
@@ -88,6 +88,31 @@ describe('Integration Tests', () => {
 			expect(newCookie).toBeTruthy();
 		});
 
+		it('should sign out and reject old session cookie', async () => {
+			const user = await createAndLoginUser({
+				name: `Signout Test User ${Date.now()}`,
+				email: `signout-test-${Date.now()}@example.com`,
+			});
+
+			const signoutReq = createApiRequest('/api/auth/signout', 'POST', {
+				cookie: user.cookie,
+			});
+			const signoutRes = await app.fetch(signoutReq, env);
+
+			expect(signoutRes.status).toBe(200);
+			const setCookie = signoutRes.headers.get('set-cookie');
+			expect(setCookie).toBeTruthy();
+
+			const protectedReq = createApiRequest('/api/protected', 'GET', {
+				cookie: user.cookie,
+			});
+			const protectedRes = await app.fetch(protectedReq, env);
+
+			expect(protectedRes.status).toBe(401);
+			const body = await protectedRes.json() as any;
+			assertUnauthorizedError(body);
+		});
+
 		it('should return a client auth error instead of 500 when the user does not exist', async () => {
 			const signinReq = createApiRequest('/api/auth/signin', 'POST', {
 				body: {

--- a/apps/fumufumu-frontend/src/app/(main)/_components/Header.tsx
+++ b/apps/fumufumu-frontend/src/app/(main)/_components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { ROUTES } from "@/config/routes";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import {
@@ -12,9 +13,36 @@ export const Header = () => {
   const router = useRouter();
   const pathname = usePathname();
   const { signout, isLoading } = useAuth();
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement | null>(null);
 
   const { reset } = useConsultationActions();
   const hasInput = useHasInput();
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        userMenuRef.current &&
+        !userMenuRef.current.contains(event.target as Node)
+      ) {
+        setIsUserMenuOpen(false);
+      }
+    };
+
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsUserMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEsc);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEsc);
+    };
+  }, []);
 
   // ロゴクリック時のハンドラ
   const handleLogoClick = () => {
@@ -46,7 +74,13 @@ export const Header = () => {
   };
 
   const handleSignout = () => {
+    setIsUserMenuOpen(false);
     signout();
+  };
+
+  const handleGoToProfile = () => {
+    setIsUserMenuOpen(false);
+    router.push(ROUTES.USER);
   };
 
   return (
@@ -62,42 +96,64 @@ export const Header = () => {
       </div>
       <div className="flex items-center space-x-4">
         <button
-          type="button"
-          onClick={() => router.push(ROUTES.USER)}
-          className="w-10 h-10 rounded-full bg-teal-100 flex items-center justify-center text-teal-600 hover:bg-teal-200 transition duration-150"
-          aria-label="プロフィール"
-        >
-          <svg
-            className="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            role="img"
-            aria-label="ユーザーアイコン"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-            />
-          </svg>
-        </button>
-        <button
           onClick={handleCreateNew}
           type="button"
           className="bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700 transition duration-150 flex items-center"
         >
           + 新規作成
         </button>
-        <button
-          onClick={handleSignout}
-          type="button"
-          disabled={isLoading}
-          className="text-sm text-gray-600 hover:text-gray-800 transition duration-150 disabled:opacity-50"
-        >
-          サインアウト
-        </button>
+        <div className="relative" ref={userMenuRef}>
+          <button
+            type="button"
+            onClick={() => setIsUserMenuOpen((prev) => !prev)}
+            className="w-10 h-10 rounded-full bg-teal-100 flex items-center justify-center text-teal-600 hover:bg-teal-200 transition duration-150"
+            aria-label="ユーザーメニュー"
+            aria-expanded={isUserMenuOpen}
+            aria-haspopup="menu"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              role="img"
+              aria-label="ユーザーアイコン"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+              />
+            </svg>
+          </button>
+
+          {isUserMenuOpen && (
+            <div
+              role="menu"
+              aria-label="ユーザーメニュー項目"
+              className="absolute right-0 mt-2 w-44 rounded-lg border border-gray-200 bg-white shadow-lg py-1 z-20"
+            >
+              <button
+                type="button"
+                role="menuitem"
+                onClick={handleGoToProfile}
+                className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+              >
+                プロフィール
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={handleSignout}
+                disabled={isLoading}
+                className="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors disabled:opacity-50"
+              >
+                サインアウト
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/apps/fumufumu-frontend/src/app/(main)/_components/Header.tsx
+++ b/apps/fumufumu-frontend/src/app/(main)/_components/Header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import type { FocusEvent, KeyboardEvent } from "react";
+import { useRef, useState } from "react";
 import { ROUTES } from "@/config/routes";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import {
@@ -14,35 +15,30 @@ export const Header = () => {
   const pathname = usePathname();
   const { signout, isLoading } = useAuth();
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
-  const userMenuRef = useRef<HTMLDivElement | null>(null);
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const menuPanelRef = useRef<HTMLDivElement | null>(null);
 
   const { reset } = useConsultationActions();
   const hasInput = useHasInput();
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        userMenuRef.current &&
-        !userMenuRef.current.contains(event.target as Node)
-      ) {
-        setIsUserMenuOpen(false);
-      }
-    };
+  const handleMenuButtonBlur = (event: FocusEvent<HTMLButtonElement>) => {
+    const nextFocused = event.relatedTarget as Node | null;
+    if (menuPanelRef.current?.contains(nextFocused)) return;
+    setIsUserMenuOpen(false);
+  };
 
-    const handleEsc = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setIsUserMenuOpen(false);
-      }
-    };
+  const handleMenuPanelBlur = (event: FocusEvent<HTMLDivElement>) => {
+    const nextFocused = event.relatedTarget as Node | null;
+    if (!event.currentTarget.contains(nextFocused)) {
+      setIsUserMenuOpen(false);
+    }
+  };
 
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleEsc);
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleEsc);
-    };
-  }, []);
+  const handleUserMenuKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key !== "Escape") return;
+    setIsUserMenuOpen(false);
+    menuButtonRef.current?.focus();
+  };
 
   // ロゴクリック時のハンドラ
   const handleLogoClick = () => {
@@ -102,10 +98,13 @@ export const Header = () => {
         >
           + 新規作成
         </button>
-        <div className="relative" ref={userMenuRef}>
+        <div className="relative">
           <button
+            ref={menuButtonRef}
             type="button"
             onClick={() => setIsUserMenuOpen((prev) => !prev)}
+            onBlur={handleMenuButtonBlur}
+            onKeyDown={handleUserMenuKeyDown}
             className="w-10 h-10 rounded-full bg-teal-100 flex items-center justify-center text-teal-600 hover:bg-teal-200 transition duration-150"
             aria-label="ユーザーメニュー"
             aria-expanded={isUserMenuOpen}
@@ -130,8 +129,11 @@ export const Header = () => {
 
           {isUserMenuOpen && (
             <div
+              ref={menuPanelRef}
               role="menu"
               aria-label="ユーザーメニュー項目"
+              onBlur={handleMenuPanelBlur}
+              onKeyDown={handleUserMenuKeyDown}
               className="absolute right-0 mt-2 w-44 rounded-lg border border-gray-200 bg-white shadow-lg py-1 z-20"
             >
               <button

--- a/apps/fumufumu-frontend/src/app/(main)/_components/Header.tsx
+++ b/apps/fumufumu-frontend/src/app/(main)/_components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import { ROUTES } from "@/config/routes";
+import { useAuth } from "@/features/auth/hooks/useAuth";
 import {
   useConsultationActions,
   useHasInput,
@@ -10,6 +11,7 @@ import {
 export const Header = () => {
   const router = useRouter();
   const pathname = usePathname();
+  const { signout, isLoading } = useAuth();
 
   const { reset } = useConsultationActions();
   const hasInput = useHasInput();
@@ -41,6 +43,10 @@ export const Header = () => {
 
     reset();
     router.push(ROUTES.CONSULTATION.NEW);
+  };
+
+  const handleSignout = () => {
+    signout();
   };
 
   return (
@@ -83,6 +89,14 @@ export const Header = () => {
           className="bg-blue-600 text-white p-2 rounded-lg hover:bg-blue-700 transition duration-150 flex items-center"
         >
           + 新規作成
+        </button>
+        <button
+          onClick={handleSignout}
+          type="button"
+          disabled={isLoading}
+          className="text-sm text-gray-600 hover:text-gray-800 transition duration-150 disabled:opacity-50"
+        >
+          サインアウト
         </button>
       </div>
     </header>

--- a/apps/fumufumu-frontend/src/features/auth/api/authApi.ts
+++ b/apps/fumufumu-frontend/src/features/auth/api/authApi.ts
@@ -1,6 +1,7 @@
 import type {
   AuthResponse,
   SigninCredentials,
+  SignoutResponse,
   SignupCredentials,
 } from "@/features/auth/types";
 import { apiClient } from "@/lib/api/client";
@@ -18,6 +19,13 @@ export const authApi = {
     return apiClient<AuthResponse>("/api/auth/signin", {
       method: "POST",
       body: JSON.stringify(data),
+      skipAuthRedirect: true,
+    });
+  },
+
+  signout: () => {
+    return apiClient<SignoutResponse>("/api/auth/signout", {
+      method: "POST",
       skipAuthRedirect: true,
     });
   },

--- a/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
+++ b/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
@@ -30,7 +30,7 @@ export const LoginForm = ({ reason, returnTo }: LoginFormProps) => {
       className: "border-amber-300 bg-amber-50 text-amber-800",
     },
     signed_out: {
-       message: "サインアウトしました。\nご利用ありがとうございました。",
+      message: "サインアウトしました。\nご利用ありがとうございました。",
       className: "border-sky-200 bg-sky-50 text-sky-800",
     },
   };

--- a/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
+++ b/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
@@ -30,7 +30,7 @@ export const LoginForm = ({ reason, returnTo }: LoginFormProps) => {
       className: "border-amber-300 bg-amber-50 text-amber-800",
     },
     signed_out: {
-      message: "サインアウトしました。ご利用ありがとうございました。",
+       message: "サインアウトしました。\nご利用ありがとうございました。",
       className: "border-sky-200 bg-sky-50 text-sky-800",
     },
   };

--- a/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
+++ b/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
@@ -29,6 +29,10 @@ export const LoginForm = ({ reason, returnTo }: LoginFormProps) => {
       message: "セッションが終了しました。再度ログインお願いします🌿",
       className: "border-amber-300 bg-amber-50 text-amber-800",
     },
+    signed_out: {
+      message: "サインアウトしました。ご利用ありがとうございました。",
+      className: "border-sky-200 bg-sky-50 text-sky-800",
+    },
   };
 
   const reasonInfo = reason ? reasonConfig[reason] : null;

--- a/apps/fumufumu-frontend/src/features/auth/hooks/useAuth.ts
+++ b/apps/fumufumu-frontend/src/features/auth/hooks/useAuth.ts
@@ -60,9 +60,23 @@ export const useAuth = () => {
     }
   };
 
+  const signout = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await authApi.signout();
+      router.push("/login?reason=signed_out");
+    } catch (_err) {
+      setError("サインアウトに失敗しました。時間をおいて再度お試しください。");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   return {
     signin,
     signup,
+    signout,
     isLoading,
     error,
   };

--- a/apps/fumufumu-frontend/src/features/auth/types/index.ts
+++ b/apps/fumufumu-frontend/src/features/auth/types/index.ts
@@ -15,3 +15,7 @@ export interface AuthResponse {
   auth_user_id: string;
   app_user_id?: number;
 }
+
+export interface SignoutResponse {
+  message: string;
+}


### PR DESCRIPTION
## やったこと
- バックエンドに `POST /api/auth/signout` を追加
- Better Auth の `signOut` 実行結果の `Set-Cookie` をレスポンスに反映し、セッションCookieを破棄できるようにした
- 認証フローテストに「サインアウト後、旧Cookieで保護APIにアクセスすると401」を追加
- フロントエンドにサインアウトAPI呼び出しを追加（`authApi` / `useAuth`）
- ヘッダーのサインアウト導線をユーザーアイコン配下メニューに集約（プロフィール / サインアウト）
- ログイン画面に `reason=signed_out` のメッセージ表示を追加
- （運用整備）`AGENTS.md` / `CLAUDE.md` に実装方針・セキュリティ方針を追記
- なぜこのPRが必要なのか
  - ログイン後にセッションを明示的に終了する手段がなく、アカウント共有端末や検証時の安全な利用に課題があったため
  - 導線をユーザーメニューに集約し、ヘッダーの情報密度を下げつつ今後の拡張余地を確保するため

## ドキュメント

- 関連チケット/設計リンクがあれば追記してください（未記載）

## 動作確認

- [ ] 動作検証不要（アプリケーションの変更無し、など）
- [x] ツールで動作検証できる
- [x] ツールで動作検証できない（動作確認の方法を記載した）
- ツールで確認できたもの
  - frontend: `pnpm lint` 成功
  - frontend: `pnpm test -- --run src/components/ui/Button.test.tsx` 成功
- ツールで確認しきれなかったもの
  - backend: テスト実行環境依存で `cloudflare:test-internal` 解決エラーが発生し、対象テストをこの環境で完走できず
- 手動確認手順
  1. ログイン後、ヘッダーのユーザーアイコンをクリック
  2. メニューから「サインアウト」を選択
  3. `/login?reason=signed_out` に遷移し、サインアウト完了メッセージが表示されることを確認
  4. 認証必須ページ（例: `/consultations`）へアクセスし、未認証としてログイン画面に遷移することを確認

<img width="1031" height="194" alt="スクリーンショット 2026-04-05 0 22 30" src="https://github.com/user-attachments/assets/afc09ca6-6592-4fb0-8a39-7b79a7f76bd9" />


## レビュー項目

- [ ] `POST /api/auth/signout` のレスポンス仕様/ステータス設計が妥当か
- [ ] ユーザーメニュー導線（位置・ラベル・操作感）がプロダクト方針に合っているか
- [ ] `AGENTS.md` / `CLAUDE.md` の運用ルール追記をこのPRに含める方針で問題ないか

### 本PRのスコープ外

- [ ] サインアウト時の確認ダイアログ追加
- [ ] ユーザーメニューの高度なキーボード操作（矢印移動など）の対応

### マージ期日 or 目標（あれば）

- 特になし

## 備考

- nasi
