### PR TITLE
LPをファーストビューに設定し、CTAをログイン遷移に変更

### DIFF
--- a/apps/fumufumu-frontend/src/app/(public)/page.tsx
+++ b/apps/fumufumu-frontend/src/app/(public)/page.tsx
@@ -1,11 +1,5 @@
+import LpWorldviewPage from "../lp/worldview-v2-popdots/page";
+
 export default function Top() {
-  return (
-    <div className="">
-      Topぺージ
-      <br />
-      ・そのうちLPとかになることを一旦想定。
-      <br />
-      ・α版としてはここから遷移させることを想定。
-    </div>
-  );
+  return <LpWorldviewPage />;
 }

--- a/apps/fumufumu-frontend/src/app/lp/worldview-v2-popdots/page.tsx
+++ b/apps/fumufumu-frontend/src/app/lp/worldview-v2-popdots/page.tsx
@@ -1,4 +1,6 @@
-export default function FumufumuLPWorldview() {
+import Link from "next/link";
+
+export default function LpWorldviewPage() {
   const steps = [
     {
       no: "1",
@@ -98,12 +100,12 @@ export default function FumufumuLPWorldview() {
             </h1>
 
             <div className="mt-14 flex flex-col items-center gap-3 sm:mt-16 sm:flex-row">
-              <button
-                type="button"
+              <Link
+                href="/login"
                 className="rounded-2xl bg-[#F5C94A] px-10 py-5 text-lg font-bold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg hover:bg-[#EAB308]"
               >
                 相談してみる
-              </button>
+              </Link>
             </div>
             <p className="mt-4 text-sm text-slate-500">
               匿名で投稿でき、公開前には運営が確認します
@@ -153,12 +155,12 @@ export default function FumufumuLPWorldview() {
                   ひとつだけ書いてみる。
                 </h2>
                 <div className="mt-7 flex flex-col items-center gap-3">
-                  <button
-                    type="button"
+                  <Link
+                    href="/login"
                     className="inline-flex items-center justify-center rounded-2xl bg-[#F5C94A] px-8 py-4 text-base font-bold text-slate-900 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg hover:bg-[#EAB308]"
                   >
                     相談してみる
-                  </button>
+                  </Link>
                   <p className="text-sm text-teal-50/80">
                     登録は1分。匿名で投稿でき、公開前には運営が確認します。
                   </p>


### PR DESCRIPTION
## 概要
- 公開トップページ（`/(public)`）で既存LPを表示するように変更
- LP内の「相談してみる」CTA 2箇所を `/login` への遷移に変更
- スペルチェック警告を避けるため、LPコンポーネント識別子名を調整

## スコープ
- LPの初期表示とCTA導線の変更のみ
- ログイン画面UIの改修は含めない

## 確認内容
- 変更差分の確認
- CTA遷移先が `/login` になる実装であることを確認