### PR TITLE
ログイン画面UI調整とLP背景グラデーション統一

### DIFF
--- a/apps/fumufumu-frontend/src/app/(auth)/layout.tsx
+++ b/apps/fumufumu-frontend/src/app/(auth)/layout.tsx
@@ -4,10 +4,13 @@ export default function AuthLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100 p-4">
-      <div className="w-full max-w-md bg-white p-8 rounded-xl shadow-2xl">
-        {children}
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[linear-gradient(135deg,#E9FBF8_0%,#F7FFF8_52%,#FFFBEA_100%)] px-4 py-10">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-20 -top-24 h-80 w-80 rounded-full bg-[#D7F7F1]/70 blur-3xl" />
+        <div className="absolute right-[-120px] top-[24%] h-72 w-72 rounded-full bg-[#EAF9FF]/55 blur-3xl" />
+        <div className="absolute -bottom-24 right-[-80px] h-96 w-96 rounded-full bg-[#FFF4C9]/55 blur-3xl" />
       </div>
+      <div className="relative w-full">{children}</div>
     </div>
   );
 }

--- a/apps/fumufumu-frontend/src/app/(public)/layout.tsx
+++ b/apps/fumufumu-frontend/src/app/(public)/layout.tsx
@@ -1,0 +1,11 @@
+export default function PublicLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className="min-h-screen bg-[linear-gradient(135deg,#E9FBF8_0%,#F7FFF8_52%,#FFFBEA_100%)]">
+      {children}
+    </div>
+  );
+}

--- a/apps/fumufumu-frontend/src/app/layout.tsx
+++ b/apps/fumufumu-frontend/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={``}>
+      <body className="min-h-screen bg-[#F7FFF8]">
         {/* ここに配置することで、アプリ内のどこからでも通知を出せます */}
         <Toaster position="top-center" />
         {children}

--- a/apps/fumufumu-frontend/src/app/lp/worldview-v2-popdots/page.tsx
+++ b/apps/fumufumu-frontend/src/app/lp/worldview-v2-popdots/page.tsx
@@ -35,9 +35,9 @@ export default function LpWorldviewPage() {
   ];
 
   return (
-    <div className="relative min-h-screen overflow-x-clip bg-[#F1F3F4] text-slate-800">
+    <div className="relative min-h-screen overflow-x-clip bg-[linear-gradient(135deg,#E9FBF8_0%,#F7FFF8_52%,#FFFBEA_100%)] text-slate-800">
       <div className="pointer-events-none absolute inset-0 z-0">
-        <div className="absolute inset-0 bg-[#F4F6F7]" />
+        <div className="absolute inset-0 bg-[linear-gradient(135deg,#E9FBF8_0%,#F7FFF8_52%,#FFFBEA_100%)]" />
 
         <div className="absolute -left-16 -top-20 h-64 w-64 rounded-full bg-[repeating-linear-gradient(45deg,rgba(124,203,147,0.58)_0_14px,transparent_14px_28px)]" />
         <div className="absolute left-[21%] -top-24 h-72 w-72 rounded-full bg-[repeating-linear-gradient(45deg,rgba(207,227,142,0.62)_0_15px,transparent_15px_30px)]" />
@@ -124,7 +124,7 @@ export default function LpWorldviewPage() {
             {steps.map((step) => (
               <div
                 key={step.no}
-                className="group relative overflow-hidden rounded-3xl border border-[#D7E3E7] bg-gradient-to-br from-white to-[#F7FAFB] px-6 py-7 shadow-[0_10px_24px_rgba(15,27,61,0.06)] transition hover:-translate-y-0.5 hover:shadow-[0_18px_38px_rgba(15,27,61,0.1)] sm:px-7 sm:py-8"
+                className="group relative overflow-hidden rounded-3xl border border-[#D7E3E7] bg-gradient-to-br from-white to-[#F7FAFB] px-6 py-7 shadow-[0_10px_24px_rgba(15,27,61,0.06)] sm:px-7 sm:py-8"
               >
                 <div className="absolute inset-x-0 top-0 h-[3px] bg-gradient-to-r from-teal-500/45 via-teal-400/20 to-transparent" />
                 <p className="pointer-events-none absolute right-4 top-[42%] hidden -translate-y-1/2 text-7xl font-black tracking-[-0.04em] text-teal-600/[0.2] md:block">

--- a/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
+++ b/apps/fumufumu-frontend/src/features/auth/components/LoginForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { useAuth } from "../hooks/useAuth";
@@ -39,61 +38,79 @@ export const LoginForm = ({ reason, returnTo }: LoginFormProps) => {
   const showReasonMessage = Boolean(reasonInfo) && !error && !isLoading;
 
   return (
-    <div className="text-center">
-      <h1 className="text-3xl font-bold text-gray-800 mb-6">ログイン</h1>
+    <div className="mx-auto w-[calc(100%-32px)] max-w-[424px]">
+      <div className="text-center">
+        <div className="mx-auto inline-flex h-[74px] min-w-[218px] items-center justify-center rounded-2xl bg-[#0F9F92] px-8 shadow-[0_8px_20px_rgba(15,159,146,0.24)]">
+          <span className="text-[48px] font-black leading-none tracking-[-0.02em] text-white">
+            ふむふむ
+          </span>
+        </div>
+        <p className="mt-5 text-[18px] font-semibold tracking-tight text-[#0F9F92] sm:text-[19px]">
+          エンジニアのお悩み相談プラットフォーム
+        </p>
+      </div>
 
-      {showReasonMessage && reasonInfo && (
-        <div
-          className={`mb-4 rounded-2xl border px-4 py-3 text-sm ${reasonInfo.className}`}
-        >
-          {reasonInfo.message}
-        </div>
-      )}
+      <div className="mt-9 rounded-[20px] border border-[rgba(126,231,220,0.6)] bg-white px-7 py-8 shadow-[0_12px_26px_rgba(13,85,77,0.12)] sm:px-8 sm:py-9">
+        {showReasonMessage && reasonInfo && (
+          <div
+            className={`mb-5 rounded-xl border px-4 py-3 text-sm ${reasonInfo.className}`}
+          >
+            {reasonInfo.message}
+          </div>
+        )}
 
-      {error && (
-        <div className="mb-4 rounded-2xl border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
-          {error}
-        </div>
-      )}
+        {error && (
+          <div className="mb-5 rounded-xl border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800">
+            {error}
+          </div>
+        )}
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <input
-            type="email"
-            placeholder="メールアドレス"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            className="w-full p-3 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
-          />
-        </div>
-        <div>
-          <input
-            type="password"
-            placeholder="パスワード"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            className="w-full p-3 border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
-          />
-        </div>
-        <Button
-          type="submit"
-          disabled={isLoading}
-          className="w-full py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition duration-150"
-        >
-          {isLoading ? "ログイン中..." : "ログイン"}
-        </Button>
-      </form>
-      <p className="mt-6 text-sm text-gray-500">
-        アカウントをお持ちでないですか？{" "}
-        <Link
-          href="/signup"
-          className="text-blue-600 hover:text-blue-700 font-medium"
-        >
-          サインアップ
-        </Link>
-      </p>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <label
+              htmlFor="login-email"
+              className="block text-left text-[14px] font-semibold text-[#0F8F84]"
+            >
+              メールアドレス
+            </label>
+            <input
+              id="login-email"
+              type="email"
+              placeholder="sample@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="h-11 w-full rounded-xl border border-[rgba(126,231,220,0.5)] bg-white px-3 text-[14px] text-slate-700 placeholder:text-[13px] placeholder:text-slate-400 transition focus:border-[rgba(15,159,146,0.8)] focus:outline-none focus:ring-2 focus:ring-[rgba(15,159,146,0.2)]"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="login-password"
+              className="block text-left text-[14px] font-semibold text-[#0F8F84]"
+            >
+              パスワード
+            </label>
+            <input
+              id="login-password"
+              type="password"
+              placeholder="••••••••"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="h-11 w-full rounded-xl border border-[rgba(126,231,220,0.5)] bg-white px-3 text-[14px] text-slate-700 placeholder:text-[13px] placeholder:text-slate-400 transition focus:border-[rgba(15,159,146,0.8)] focus:outline-none focus:ring-2 focus:ring-[rgba(15,159,146,0.2)]"
+            />
+          </div>
+
+          <Button
+            type="submit"
+            disabled={isLoading}
+            className="h-11 w-full rounded-xl bg-[#0F9F92] text-[15px] font-semibold text-white shadow-none transition hover:bg-[#0C8F84] disabled:bg-[#70CFC5]"
+          >
+            {isLoading ? "ログイン中..." : "ログイン"}
+          </Button>
+        </form>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 概要
- ログイン画面のUIをデザインに合わせて調整
- サブタイトル、フォーム文字サイズ、カード/入力枠線トーンを微調整
- LPと公開ページの背景をログイン画面と同系グラデーションに統一
- ページ最下部まで背景が切れないように親レイアウト側で背景を保持

## 変更内容
- `app/(auth)/layout.tsx`: ログイン画面背景の調整
- `features/auth/components/LoginForm.tsx`: ロゴ、サブコピー、フォームUIのスタイル調整
- `app/(public)/layout.tsx`: 公開ページ全体背景の追加
- `app/lp/worldview-v2-popdots/page.tsx`: LP背景を同系グラデーションへ統一
- `app/layout.tsx`: body背景のフォールバックを追加

ログイン画面
<img width="1985" height="1059" alt="スクリーンショット 2026-04-24 17 35 39" src="https://github.com/user-attachments/assets/2851360a-572e-41d3-9c98-e03f4b9cce73" />


## 確認
- `pnpm --dir apps/fumufumu-frontend lint`
- `pnpm --dir apps/fumufumu-frontend build`