### PR TITLE
🐛debug(backend): Better Auth の password hash を Web Crypto PBKDF2 に差し替え Workers Free の CPU 制限を回避（Phase 1.5 / #123）

### DIFF
--- a/apps/fumufumu-backend/src/auth.ts
+++ b/apps/fumufumu-backend/src/auth.ts
@@ -1,6 +1,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import type { Env, DbInstance } from './index';
+import { hashPasswordPbkdf2, verifyPasswordPbkdf2 } from './lib/password-pbkdf2';
 
 /**
  * Drizzleインスタンスと環境変数を受け取って Better Auth インスタンスを生成する関数
@@ -22,6 +23,14 @@ export function createBetterAuth(db: DbInstance, env: Env) {
 		emailAndPassword: {
 			enabled: true,
 			autoSignIn: true,
+			// Better Auth のデフォルト hash (scrypt 系) は Cloudflare Workers Free の
+			// 10ms CPU 制限を超え、signup / login が 503 で失敗するため、
+			// Web Crypto API (PBKDF2) ベースの軽量実装に差し替える。
+			// 詳細は src/lib/password-pbkdf2.ts のコメント / Issue #123 / 実装計画 07 Phase 1.5 を参照。
+			password: {
+				hash: hashPasswordPbkdf2,
+				verify: verifyPasswordPbkdf2,
+			},
 		},
 		user: {
 			modelName: "authUsers",

--- a/apps/fumufumu-backend/src/lib/password-pbkdf2.ts
+++ b/apps/fumufumu-backend/src/lib/password-pbkdf2.ts
@@ -1,0 +1,134 @@
+/**
+ * Web Crypto API ベースの PBKDF2 password hash / verify 実装。
+ *
+ * Cloudflare Workers Free プランの 10ms CPU 制限内に収まるよう、iterations を抑えている。
+ * Better Auth のデフォルト (scrypt 系) は Workers Free では CPU 制限超過で 503 になるため、
+ * その代替として `emailAndPassword.password.hash / verify` に差し込んで使う。
+ *
+ * 形式: `pbkdf2$<iterations>$<salt-b64>$<hash-b64>`
+ *   - 先頭の `pbkdf2` は version / algorithm tag
+ *   - iterations は decode 時に hash 文字列から復元できる（後で値を上げても旧 hash を verify 可能）
+ *
+ * セキュリティ上の妥協:
+ *   - OWASP 2023 の PBKDF2-HMAC-SHA256 推奨は 600,000 iterations。
+ *   - 本実装は Workers Free の CPU 制約に合わせるため、初期値を 50,000 に設定する。
+ *   - 将来 Workers Standard plan に upgrade した場合、または別の解決策が取れた場合は
+ *     iterations を引き上げる（既存 hash は format から iterations を読めるため互換維持できる）。
+ *   - 詳細は ADR 008 / Issue #123 / 実装計画 07 の Phase 1.5 を参照。
+ */
+
+const ALGORITHM_TAG = "pbkdf2";
+const HASH_FUNCTION: AlgorithmIdentifier = "SHA-256";
+const SALT_BYTES = 16;
+const KEY_BYTES = 32;
+
+/**
+ * 初期 iterations 数。
+ *
+ * 値の決め方:
+ *   - Workers Free の 10ms CPU 制限に収まる範囲で大きい値を選ぶ
+ *   - 実測してから必要に応じて調整する（`wrangler tail` で CPU 時間を観測）
+ *   - hash 文字列に iterations を埋め込んでいるため、後から引き上げても旧 hash の verify は壊れない
+ */
+const DEFAULT_ITERATIONS = 50_000;
+
+function bufferToBase64(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function base64ToBuffer(b64: string): ArrayBuffer {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+async function deriveBits(
+  password: string,
+  salt: ArrayBuffer,
+  iterations: number,
+): Promise<ArrayBuffer> {
+  const encoded = new TextEncoder().encode(password);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoded,
+    "PBKDF2",
+    false,
+    ["deriveBits"],
+  );
+  return crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations,
+      hash: HASH_FUNCTION,
+    },
+    key,
+    KEY_BYTES * 8,
+  );
+}
+
+/**
+ * 定数時間比較。
+ * 早期 return すると timing attack で hash の中身が漏れうるため、長さチェック以外で短絡しない。
+ */
+function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a[i] ^ b[i];
+  }
+  return diff === 0;
+}
+
+/**
+ * Password を PBKDF2-HMAC-SHA256 で hash する。
+ * Better Auth の `emailAndPassword.password.hash` に渡す想定。
+ */
+export async function hashPasswordPbkdf2(password: string): Promise<string> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES));
+  const derived = await deriveBits(password, salt.buffer, DEFAULT_ITERATIONS);
+  return [
+    ALGORITHM_TAG,
+    DEFAULT_ITERATIONS.toString(),
+    bufferToBase64(salt),
+    bufferToBase64(derived),
+  ].join("$");
+}
+
+/**
+ * 保存済み hash と照合する。
+ * Better Auth の `emailAndPassword.password.verify` に渡す想定。
+ */
+export async function verifyPasswordPbkdf2(args: {
+  password: string;
+  hash: string;
+}): Promise<boolean> {
+  const { password, hash } = args;
+  const parts = hash.split("$");
+  if (parts.length !== 4) return false;
+  const [tag, iterStr, saltB64, expectedB64] = parts;
+  if (tag !== ALGORITHM_TAG) return false;
+
+  const iterations = Number.parseInt(iterStr, 10);
+  if (!Number.isFinite(iterations) || iterations <= 0) return false;
+
+  let saltBuf: ArrayBuffer;
+  let expectedBuf: ArrayBuffer;
+  try {
+    saltBuf = base64ToBuffer(saltB64);
+    expectedBuf = base64ToBuffer(expectedB64);
+  } catch {
+    return false;
+  }
+
+  const derived = await deriveBits(password, saltBuf, iterations);
+  return constantTimeEqual(new Uint8Array(derived), new Uint8Array(expectedBuf));
+}

--- a/apps/fumufumu-backend/src/test/lib/password-pbkdf2.test.ts
+++ b/apps/fumufumu-backend/src/test/lib/password-pbkdf2.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  hashPasswordPbkdf2,
+  verifyPasswordPbkdf2,
+} from "../../lib/password-pbkdf2";
+
+describe("password-pbkdf2", () => {
+  it("hash と verify が round-trip する", async () => {
+    const password = "correct horse battery staple";
+    const hash = await hashPasswordPbkdf2(password);
+    expect(hash.startsWith("pbkdf2$")).toBe(true);
+
+    const ok = await verifyPasswordPbkdf2({ password, hash });
+    expect(ok).toBe(true);
+  });
+
+  it("同じ password でも salt が異なるため hash 文字列は毎回変わる", async () => {
+    const password = "same-input-different-output";
+    const hashA = await hashPasswordPbkdf2(password);
+    const hashB = await hashPasswordPbkdf2(password);
+
+    // 文字列としては別だが、verify はどちらも通る
+    expect(hashA).not.toBe(hashB);
+    expect(await verifyPasswordPbkdf2({ password, hash: hashA })).toBe(true);
+    expect(await verifyPasswordPbkdf2({ password, hash: hashB })).toBe(true);
+  });
+
+  it("間違った password の verify は false を返す", async () => {
+    const hash = await hashPasswordPbkdf2("the-real-password");
+    const ok = await verifyPasswordPbkdf2({
+      password: "wrong-guess",
+      hash,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("hash format が壊れている場合は false を返す（例外を投げない）", async () => {
+    const password = "any";
+    expect(await verifyPasswordPbkdf2({ password, hash: "" })).toBe(false);
+    expect(await verifyPasswordPbkdf2({ password, hash: "not-a-hash" })).toBe(
+      false,
+    );
+    expect(
+      await verifyPasswordPbkdf2({
+        password,
+        hash: "pbkdf2$abc$###bad-b64###$###bad-b64###",
+      }),
+    ).toBe(false);
+    expect(
+      await verifyPasswordPbkdf2({
+        password,
+        hash: "scrypt$1$salt$hash",
+      }),
+    ).toBe(false);
+  });
+
+  it("hash 文字列に iterations が埋め込まれている（将来引き上げ時の互換維持用）", async () => {
+    const hash = await hashPasswordPbkdf2("anything");
+    const parts = hash.split("$");
+    expect(parts).toHaveLength(4);
+    expect(parts[0]).toBe("pbkdf2");
+    expect(Number.parseInt(parts[1], 10)).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 背景

Phase 1a Step 3 (#124) で frontend を Cloudflare workers.dev に deploy した直後、production で `POST /api/auth/signup` が **503 Service Unavailable** で失敗することが判明した。`wrangler tail` の出力は `Error: Worker exceeded CPU time limit.`。

原因は Better Auth のデフォルト password hashing (scrypt 系) が Cloudflare Workers Free の **10ms CPU 制限** を超えるため。ADR 008 のコスト試算は Standard plan ($5/月) 前提だが、商用化前はコストを掛けない方針のため、Free 維持で解決する必要がある。

## このPRで解決すること

Better Auth の hash 実装を **Web Crypto API ベースの PBKDF2-HMAC-SHA256** に差し替え、Workers Free の CPU 制限内で signup / signin の hash 処理が完了する状態にする。

## 解決方法

### Better Auth の hash 差し込み

Better Auth は `emailAndPassword.password` に custom `hash` / `verify` を受け付ける設計になっているため、ここに Web Crypto API ベースの実装を差し込む。

### hash の format

```
pbkdf2$<iterations>$<salt-b64>$<hash-b64>
```

iterations を hash 文字列に埋め込んでいるため、将来引き上げても旧 hash の verify は壊れない（互換維持）。

### iterations の妥協

| 観点 | 値 |
|---|---|
| OWASP 2023 推奨（PBKDF2-HMAC-SHA256） | 600,000 |
| **本実装の初期値** | **50,000** |

Workers Free の 10ms CPU 制限内に収めるための妥協。Standard plan upgrade などで CPU 制限を緩和した時に引き上げる前提でコード内コメントに明記してある。

## 動作確認

| 項目 | 結果 |
|---|---|
| PBKDF2 単体テスト（round-trip / salt 違い / 不正入力 / format 互換性） | 5 件 pass |
| backend 全テスト | 164 件 pass（既存 159 + 新規 5） |
| production `POST /api/auth/signup` | HTTP 200 OK（`wrangler tail` 実測） |
| production `POST /api/auth/signin` | HTTP 200 OK |

## このPRで意図的に含めていないこと

### Cookie cross-domain 問題（#126）

signin が HTTP 200 で返るようになった一方、production の `workers.dev` 上では frontend と backend がサブドメイン違いのため、SSR 認証 guard が Cookie を見つけられず `/login?reason=unauthorized` にリダイレクトされる。これは `*.workers.dev` が Public Suffix List に登録されていることに起因する技術的制約で、**custom domain 移行（Step 10）で根本解決する**想定。詳細は #126。

つまり本 PR 単体では「production の workers.dev で login → 保護ページが見える」状態にはならない。ローカル開発では login まで完全に動作する。

### iterations の引き上げ

OWASP 推奨値（600,000）への引き上げは plan 判断（Standard upgrade）次第のため見送り。コメントで将来の検討事項として明記。

## 変更内容

- 新規: `apps/fumufumu-backend/src/lib/password-pbkdf2.ts`（PBKDF2 hash / verify 実装）
- 新規: `apps/fumufumu-backend/src/test/lib/password-pbkdf2.test.ts`（単体テスト 5 件）
- 修正: `apps/fumufumu-backend/src/auth.ts`（`emailAndPassword.password` に custom hash / verify を差し込み）

## レビュー時に見てほしい点

- PBKDF2 実装の妥当性（特に constant-time 比較・salt 生成・iterations の埋め込み）
- iterations `50_000` の妥協が許容範囲か（コードコメントの将来引き上げ前提も含めて）
- Better Auth `emailAndPassword.password` への差し込み箇所が正しいか

## 関連

- 解決する Issue: #123（backend 認証の CPU 時間制限）
- 派生 Issue: #126（workers.dev での Cookie cross-domain、Step 10 で解決予定）
- 実装計画: [`docs/projects/07-cicd-and-deployment.md`](docs/projects/07-cicd-and-deployment.md) Phase 1.5
- ADR: [`docs/design/adr/008-frontend-deployment-platform-and-split-cicd.md`](docs/design/adr/008-frontend-deployment-platform-and-split-cicd.md)
- 直近 PR: #125（Step 4 清書）