### PR TITLE
✨feat(admin): /admin の権限制御 MVP の土台（ADR / 雛形ページ / users.role 追加）

### DIFF
--- a/apps/fumufumu-backend/drizzle/0010_aspiring_blacklash.sql
+++ b/apps/fumufumu-backend/drizzle/0010_aspiring_blacklash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `role` text DEFAULT 'user' NOT NULL;

--- a/apps/fumufumu-backend/drizzle/meta/0010_snapshot.json
+++ b/apps/fumufumu-backend/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,863 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cdf40d22-8e8b-4799-bf28-977071fc9f1e",
+  "prevId": "ae1068c3-2b85-4a8e-bb60-4edec1516a7b",
+  "tables": {
+    "advices": {
+      "name": "advices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consultation_id": {
+          "name": "consultation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "advices_consultation_id_consultations_id_fk": {
+          "name": "advices_consultation_id_consultations_id_fk",
+          "tableFrom": "advices",
+          "tableTo": "consultations",
+          "columnsFrom": [
+            "consultation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "advices_author_id_users_id_fk": {
+          "name": "advices_author_id_users_id_fk",
+          "tableFrom": "advices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_accounts": {
+      "name": "auth_accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_accounts_user_id_auth_users_id_fk": {
+          "name": "auth_accounts_user_id_auth_users_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_sessions": {
+      "name": "auth_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_unique": {
+          "name": "auth_sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_auth_users_id_fk": {
+          "name": "auth_sessions_user_id_auth_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_users": {
+      "name": "auth_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "auth_users_email_unique": {
+          "name": "auth_users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_verifications": {
+      "name": "auth_verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "consultations": {
+      "name": "consultations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "hidden_at": {
+          "name": "hidden_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "solved_at": {
+          "name": "solved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_consultations_created_at": {
+          "name": "idx_consultations_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "consultations_author_id_users_id_fk": {
+          "name": "consultations_author_id_users_id_fk",
+          "tableFrom": "consultations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_checks": {
+      "name": "content_checks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_last_error": {
+          "name": "notify_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "uq_content_checks_target": {
+          "name": "uq_content_checks_target",
+          "columns": [
+            "target_type",
+            "target_id"
+          ],
+          "isUnique": true
+        },
+        "idx_content_checks_status_created_at": {
+          "name": "idx_content_checks_status_created_at",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "consultation_taggings": {
+      "name": "consultation_taggings",
+      "columns": {
+        "consultation_id": {
+          "name": "consultation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_consultation_taggings_tag_id": {
+          "name": "idx_consultation_taggings_tag_id",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "consultation_taggings_consultation_id_consultations_id_fk": {
+          "name": "consultation_taggings_consultation_id_consultations_id_fk",
+          "tableFrom": "consultation_taggings",
+          "tableTo": "consultations",
+          "columnsFrom": [
+            "consultation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "consultation_taggings_tag_id_tags_id_fk": {
+          "name": "consultation_taggings_tag_id_tags_id_fk",
+          "tableFrom": "consultation_taggings",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "consultation_taggings_consultation_id_tag_id_pk": {
+          "columns": [
+            "consultation_id",
+            "tag_id"
+          ],
+          "name": "consultation_taggings_consultation_id_tag_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "auth_mappings": {
+      "name": "auth_mappings",
+      "columns": {
+        "app_user_id": {
+          "name": "app_user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_mappings_app_user_id_users_id_fk": {
+          "name": "auth_mappings_app_user_id_users_id_fk",
+          "tableFrom": "auth_mappings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "app_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_mappings_auth_user_id_auth_users_id_fk": {
+          "name": "auth_mappings_auth_user_id_auth_users_id_fk",
+          "tableFrom": "auth_mappings",
+          "tableTo": "auth_users",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/fumufumu-backend/drizzle/meta/_journal.json
+++ b/apps/fumufumu-backend/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1776348875034,
       "tag": "0009_new_patch",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1780778116480,
+      "tag": "0010_aspiring_blacklash",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/fumufumu-backend/src/db/schema/user.ts
+++ b/apps/fumufumu-backend/src/db/schema/user.ts
@@ -2,11 +2,15 @@ import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
 import { authUsers } from "./auth";
 
+export const USER_ROLES = ["user", "admin"] as const;
+export type UserRole = (typeof USER_ROLES)[number];
+
 // 業務ロジックの主軸となる users テーブル
 export const users = sqliteTable("users", {
 	id: integer("id").primaryKey({ autoIncrement: true }),
 	name: text("name").notNull(),
 	disabled: integer("disabled", { mode: "boolean" }).default(false).notNull(),
+	role: text("role", { enum: USER_ROLES }).notNull().default("user"),
 	createdAt: integer("created_at", { mode: "timestamp_ms" })
 		.default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
 		.notNull(),

--- a/apps/fumufumu-frontend/src/app/(main)/admin/page.tsx
+++ b/apps/fumufumu-frontend/src/app/(main)/admin/page.tsx
@@ -1,0 +1,8 @@
+export default function AdminPage() {
+  return (
+    <div className="max-w-4xl mx-auto w-full">
+      <h1 className="text-2xl font-bold">Admin</h1>
+      <p className="mt-4">管理画面（仮）</p>
+    </div>
+  );
+}

--- a/docs/design/adr/010-admin-permissions-mvp.md
+++ b/docs/design/adr/010-admin-permissions-mvp.md
@@ -1,0 +1,198 @@
+# [ADR] 管理画面（/admin）の権限制御 MVP 方針
+
+* **Status**: Accepted
+* **Date**: 2026-06-07
+
+---
+
+## 0. このADRで行った意思決定
+
+### 比較した論点
+
+1. ユーザーの権限を `is_admin` boolean で持つか、`role` enum で持つか
+2. 権限の付与/剥奪をどの経路で行うか（DB 直 UPDATE / 管理者専用 API / 両方）
+3. バックエンドの認可をどの粒度で掛けるか（機能別の辞書 / `/api/admin/*` 一律 / 個別ハンドラ）
+4. フロントエンドで「一般ユーザーに見せない」をどう実装するか（layout guard / コンポーネント内 if 分岐 / middleware）
+
+### 評価観点（Decision Drivers）
+
+- 個人開発規模で運用負荷を増やさないこと
+- 公開リポジトリであり、`/admin` 系 API のエンドポイントは誰でも grep できる前提で安全であること
+- 将来 `moderator` のような中間ロールを追加しても、破壊的変更にならないこと
+- フロントエンドの「admin 判定」が `if (isAdmin)` で各所に散らばらないこと
+- 認可機構そのものの実装 bug が単一障害点にならないこと（権限付与 API のような攻撃面を必要以上に増やさない）
+
+### 最終決定
+
+- ユーザー権限は `users.role` enum (`'user' | 'admin'`) で管理する。初期値は `'user'`、`NOT NULL`、デフォルト制約あり
+- 権限付与は **当面 DB 直 UPDATE（wrangler d1 execute）のみ** とし、権限変更 API は MVP では作らない
+- バックエンドは `/api/admin/*` 配下に `adminGuard` middleware を必須化し、`role === 'admin'` 以外は 404 を返す（403 ではなく 404 にすることで admin API の存在を漏らさない）
+- フロントエンドは `(main)/admin/layout.tsx` で server-side に role を検査し、admin でなければ `notFound()` を返す。UI 上の admin ナビ表示は、セッション由来の `role` を 1 箇所で参照する仕組みに集約する
+
+### 採用しなかった案
+
+- `users.is_admin` boolean
+  - 却下理由: 将来 `moderator` 等を増やす際に「複数 boolean 列の組合せ」になり、状態の一意性が崩れる。enum なら 1 列で現在の権限が確定する。
+- 権限変更 API を MVP から提供する
+  - 却下理由: MVP 時点では role 付け替えの頻度が低く API を作る ROI が見合わない。一方で「権限を変更できる API」は最大級の攻撃面になり、その認可 bug は全権限崩壊につながる。MVP では作らない方が安全。
+- 機能ごとの権限辞書（feature → required role のマップ）
+  - 却下理由: MVP 時点では `admin` 1 種類しか無く、辞書を引くオーバーヘッドだけが残る。ロールが 2 種類以上になった時点で導入する。
+- フロントエンドで Server Component / Client Component それぞれに `if (isAdmin)` を書く方式
+  - 却下理由: 表示判定が各所に散らばり、漏れが必ず出る。layout 一段とナビ用フックの 1 箇所に閉じ込める。
+- middleware (proxy.ts) で admin guard を掛ける方式
+  - 却下理由: 当プロジェクトは ADR 008-frontend-deployment で Node Middleware を撤去済み。layout guard 方式に統一する。
+
+---
+
+## 1. 背景
+
+`/admin` ページの雛形を追加した（feature/admin-permissions ブランチ）。この管理画面では以下を扱う想定:
+
+- ユーザー一覧の管理（権限付与、垢 BAN 操作）
+- 投稿チェック機能の管理（ADR 007 / ADR 009 で定義した consultation / advice の承認・却下と、承認時のメール送信）
+
+現時点で問題なのは、バックエンドに既に存在する `/api/admin/content-check/*` 系のルートが `authGuard`（ログイン済みかどうか）しか掛かっていない点である。fumufumu は公開リポジトリのため、ルーティングは誰でも grep できる。**ログインさえしていれば curl で承認 API を叩ける状態** であり、ここを塞ぐのが今回の最優先課題となる。
+
+加えて、`/admin` ページの追加に伴い「フロントエンドで admin 以外に画面を見せない」「画面の存在自体を露出させない」も同時に整える必要がある。
+
+---
+
+## 2. DB 設計（`is_admin` vs `role` の比較）
+
+| 観点 | `is_admin` boolean | `role` enum (採用) |
+|---|---|---|
+| 列数 | 1 (現状) | 1 |
+| 状態の一意性 | OK（true/false のみ） | OK（enum で一意） |
+| 中間ロール追加時 | `is_moderator` 等の列追加 → 列の組合せ管理が必要 | 値を増やすだけ |
+| 既存ユーザーへの移行 | デフォルト false で済む | デフォルト `'user'` で済む |
+| クエリの素直さ | `WHERE is_admin = 1` | `WHERE role = 'admin'` |
+| 「現在の権限」を 1 箇所で読める | ✗（複数列を見ないと分からない場合あり） | ✓ |
+
+採用: `role` enum (`'user' | 'admin'`)。
+
+- `users` テーブルに `role TEXT NOT NULL DEFAULT 'user'` を追加する
+- アプリ側では `type UserRole = 'user' | 'admin'` を 1 箇所で定義し、DB / API / フロントで共有する
+- 既存ユーザーは migration で全て `'user'` になる。初期管理者は migration 後に手動 UPDATE で付与する
+
+将来 `moderator` を追加する場合は enum に値を増やすだけで済むため、テーブル schema 変更は不要になる（drizzle の enum 型定義の更新のみ）。
+
+---
+
+## 3. 権限付与/剥奪の経路
+
+### 採用: DB 直 UPDATE のみ（MVP）
+
+```sh
+wrangler d1 execute <db> --remote \
+  --command "UPDATE users SET role = 'admin' WHERE id = <id>"
+```
+
+理由:
+
+- MVP 時点では role 付け替えの頻度が低く、API を作る ROI が見合わない（初期管理者の bootstrap と、稀に発生する追加付与のみを想定）
+- 「権限を変更できる API」自体が最大級の攻撃面になる。その API の認可 bug = 全権限崩壊に直結する。MVP では作らない方が安全
+- DB 直 UPDATE は wrangler 経由で実施するため、Cloudflare アカウントへのアクセス権を持つ運営メンバーに操作を限定できる
+
+### MVP で `/admin` の「ユーザー管理」画面が扱う範囲
+
+- 一覧表示（id, name, role, disabled, createdAt 程度）
+- BAN フラグ (`users.disabled`) の切り替え ← これは API 化する（運営オペレーションで頻度が出る想定）
+- **role の付け替えは UI から行わない**（DB 直のみ）
+
+`disabled` の切り替えは「ユーザーをログイン不能にする / 投稿不能にする」操作であり、誤操作の影響範囲が `role` 変更より限定的なため API 化する。`role` 変更は権限の昇格そのものであり、影響範囲・攻撃面の観点から MVP では UI/API を切らない。
+
+### 採用しなかった案
+
+- 管理者 API による付与/剥奪
+  - 上記の通り、攻撃面と MVP 時点の運用ニーズが釣り合わないため不採用。将来見直し条件は §6 に記載。
+
+---
+
+## 4. バックエンドの認可方針
+
+### 採用: `/api/admin/*` 全体に `adminGuard` middleware を必須化する
+
+実装方針:
+
+- `authGuard` の後段に `adminGuard` を追加する
+  - `authGuard` が確定させた `appUserId` を使って `users.role` を引く
+  - `role !== 'admin'` の場合は `404 Not Found` を返す（403 ではなく 404）
+- `/api/admin` 配下のルート登録時に必ず `authGuard, adminGuard` をセットで適用するルールにする
+  - 既存の `admin-content-check.controller.ts` も同様に書き換える
+  - 「admin 系ルートは `app.route('/admin/...', ...)` の段で middleware を強制」する形にして、個別ハンドラで掛け忘れが起きないようにする
+
+### なぜ 403 ではなく 404 か
+
+- 公開リポジトリのため、admin API のパスは grep で完全に把握できる前提
+- 403 を返すと「このパスは存在し、権限不足である」ことが確定情報として相手に渡る
+- 404 を返せば「そもそも admin API が存在するかどうか」の確証を与えない（実態は変わらないが、不要な情報を渡さない）
+- 一般ユーザーが誤って踏むことは想定しないため、UX 上のデメリットも無い
+
+### 機能別の権限辞書を作らない理由
+
+- 現状ロールは `user` / `admin` の 2 値のみ。辞書を引く構造を作っても、全エントリが「admin 必須」になる
+- 将来 `moderator` を追加して「投稿チェックは moderator 以上、ユーザー BAN は admin のみ」のような分岐が必要になった段階で、`role → 許可エンドポイント` のマップを導入する
+- それまでは「`/api/admin/*` は admin role 必須」の 1 ルールで管理する
+
+---
+
+## 5. フロントエンドの方針
+
+### 採用: layout レベルでの server-side guard + セッション由来の `role` を 1 箇所で読む
+
+実装方針:
+
+1. **`(main)/admin/layout.tsx` を新設し、ここで role を検査する**
+   - Server Component で session を取得 → `role !== 'admin'` なら `notFound()` を呼ぶ
+   - これで `/admin/**` 配下は layout 一段で守られる。個別ページに guard を書かない
+2. **ヘッダー等の admin ナビ表示も、セッション由来の `role` を 1 箇所で参照する**
+   - 例: `useCurrentUserRole()` のような薄い hook、または Server Component で session から取った role を props で受け渡す
+   - 各コンポーネントで `if (isAdmin)` を書かない。表示判定は 1 箇所に閉じる
+3. **404 と整合させる**
+   - admin でない人間が `/admin` を直打ちしても `notFound()` で 404 化される
+   - これにより「admin 画面の存在自体」をフロントエンドからも露出させない
+
+### CLAUDE.md の `useEffect` 禁止ルールとの整合
+
+- role の取得・判定はすべて Server Component / server-side session lookup で完結させる
+- クライアント側で fetch して role を判定する `useEffect` は使わない
+- これは CLAUDE.md のフロントエンドルール（`useEffect` を既定で使わない）と自然に整合する
+
+---
+
+## 6. 期待効果とトレードオフ
+
+### 期待効果
+
+- 公開リポジトリ前提でも `/api/admin/*` を curl で直叩きされない（404 で存在も曖昧化）
+- 権限変更 API という最大の攻撃面を MVP に持ち込まない
+- フロントエンドの admin 判定が layout 1 段とナビ用の 1 箇所に閉じ、`if (isAdmin)` の散乱を回避
+- `role` enum により、将来 `moderator` を増やしても schema 変更不要
+
+### トレードオフ
+
+- 初期管理者の付与は wrangler d1 execute での手動 UPDATE が必要（Cloudflare アカウントへのアクセス権を持つ運営メンバーのみ実行可）
+- `/admin` UI から role の付け替えはできない（role 操作が必要なときは DB 直 UPDATE で対応する前提）
+- 404 化により「admin 画面が存在しない」のか「権限不足で見えない」のか、開発者本人が見ても挙動から区別できない（ログでは区別可能にする）
+
+---
+
+## 7. 将来の見直し条件
+
+- role の付与/剥奪頻度が増え、DB 直 UPDATE による運用がトイル化する
+  - → 権限付与 API + 監査ログを導入し、`/admin` UI から role 操作可能にする
+- 中間ロール（例: `moderator`）が必要になる
+  - → `role` enum に値を追加し、「ロール → 許可エンドポイント」のマップを導入
+- 監査要求が強くなる
+  - → `role` 変更ログテーブル、または `users` の `role_updated_at` / `role_updated_by` 追加を検討
+- 同時にロールが複数必要なユーザーが現れる
+  - → `users.role` を `user_roles` 多対多テーブルへ移行（schema migration が発生する）
+
+---
+
+## 8. 参照
+
+- ADR 007: `docs/design/adr/007-content-check-mvp-operation-strategy.md`（投稿チェック機能の MVP 運用）
+- ADR 009: `docs/design/adr/009-email-notification-delivery-strategy-mvp.md`（承認時メール送信）
+- ADR 008: `docs/design/adr/008-frontend-deployment-platform-and-split-cicd.md`（Node Middleware 撤去の経緯）
+- CLAUDE.md: フロントエンドの `useEffect` 既定禁止ルール


### PR DESCRIPTION
## 背景

- 公開リポジトリの `apps/fumufumu-backend/src/routes/admin-content-check.controller.ts` にある `/api/admin/content-check/*` 系のルートは現状 `authGuard`（ログイン済みかどうか）しか掛かっておらず、**ログインさえしていれば誰でも curl で投稿の承認/却下 API を叩ける状態** になっている
- 公開リポジトリのため、admin 系エンドポイントのパスは grep で完全に把握できる前提で考える必要がある
- 加えて、フロントエンドに `/admin` 画面を順次追加していくにあたり「一般ユーザーには画面の存在自体を露出させない」要件もある
- 上記を踏まえ、まずは設計判断と DB 土台だけ先に固める

## このPRで解決すること

- `/admin` 系の権限制御に関する設計判断を ADR として固定する
- 権限管理の DB 列（`users.role`）を追加し、ローカル / リモート D1 に反映する
- 後続 PR で `adminGuard` 実装やフロントエンド guard を追加できる状態にする

**このPR単体では認可は有効にならない**（既存挙動を変えない。土台のみ）。

## 含まれる変更

| 変更 | 内容 |
|---|---|
| `apps/fumufumu-frontend/src/app/(main)/admin/page.tsx` | `/admin` ページの雛形（プレースホルダ）。`(main)` route group に置くことで既存の Better Auth session guard と layout を流用 |
| `docs/design/adr/010-admin-permissions-mvp.md` | 権限制御の MVP 方針 ADR |
| `apps/fumufumu-backend/src/db/schema/user.ts` | `USER_ROLES` (`'user' \| 'admin'`) と `users.role` 列を追加（既存の `content_checks.status` パターンに倣う） |
| `apps/fumufumu-backend/drizzle/0010_aspiring_blacklash.sql` | `ALTER TABLE users ADD role TEXT NOT NULL DEFAULT 'user'` |

## ADR 010 の要点（詳細は ADR 本文）

1. **DB 設計**: `users.role` enum を採用。`is_admin` boolean は将来 `moderator` 等を増やす際に列の組合せ管理が崩れるため不採用
2. **権限付与経路**: MVP では **DB 直 UPDATE のみ**。権限変更 API は MVP では作らない（最大の攻撃面を持ち込まない判断）
3. **バックエンド認可**: `/api/admin/*` 全体に `adminGuard` を必須化し、未認可時は **403 ではなく 404** を返す（admin API の存在自体を露出させない）
4. **フロントエンド**: `(main)/admin/layout.tsx` で server-side に `notFound()`、UI 露出はセッション由来 role を 1 箇所参照に集約（`if (isAdmin)` 散乱と `useEffect` 利用を回避し CLAUDE.md ルールと整合）

## このPRで意図的に含めていないこと

- **`adminGuard` middleware の実装と `/api/admin/*` への適用** → 後続 PR
- **フロントエンド `(main)/admin/layout.tsx` での server-side guard** → 後続 PR
- **`/admin` UI の実機能**（ユーザー一覧、BAN フラグ、投稿チェック画面） → 後続 PR
- **権限変更 API** → ADR 010 の決定により MVP では作らない

## リリース戦略

DB migration を **バックエンドコード変更とは別 PR で先行リリース** する方針を取っている。

- 0010 は additive only (`ALTER TABLE ADD ... DEFAULT 'user' NOT NULL`) のため、既存 SELECT/INSERT に影響なし
- 現行コードは `role` 列を参照していないため、本 PR 単体をデプロイしてもサービス挙動は変わらない
- Cloudflare D1 と Workers のデプロイは原子的に揃えられないため、「コードが新スキーマを参照するが DB は旧スキーマ」のレースを避けるためにこの順序を取る
- 次 PR で `adminGuard` 有効化時に **admin が誰もいない状態を作らない** よう、本 PR 段階で初期管理者を DB 直 UPDATE で付与済み

## 動作確認

- ローカル: `pnpm local:migration` で 0010 適用、`PRAGMA table_info(users)` で `role TEXT NOT NULL DEFAULT 'user'` を確認、既存行が `'user'` でバックフィルされていることを確認
- リモート D1: `pnpm d1:migrations:apply:remote` で 0010 適用済み（同 PR で 0009 の未適用分も併せて適用 — どちらも additive のため安全）。同様の `PRAGMA` / バックフィル確認済み
- 初期管理者 1 名を `users.role = 'admin'` に DB 直 UPDATE で付与済み
- `/admin` ページは現状プレースホルダのみ表示

## レビュー時に見てほしい点

- ADR 010 の 4 つの決定（特に「権限変更 API を作らない」「未認可時 404」）が許容範囲か
- `users.role` の enum 値（`'user' | 'admin'`）の妥当性。将来 `moderator` 等を増やす想定で十分か
- リリース順序（DB 先行 → コード後追い）の方針

## 関連

- ADR: [`docs/design/adr/010-admin-permissions-mvp.md`](docs/design/adr/010-admin-permissions-mvp.md)
- 関連 ADR: [`docs/design/adr/007-content-check-mvp-operation-strategy.md`](docs/design/adr/007-content-check-mvp-operation-strategy.md) / [`docs/design/adr/009-email-notification-delivery-strategy-mvp.md`](docs/design/adr/009-email-notification-delivery-strategy-mvp.md)
- 後続 PR (予定): `adminGuard` middleware と `/api/admin/*` への適用、フロントエンド layout guard、`/admin` UI の実機能