### PR TITLE
✨feat(admin): /api/admin/* と /admin/** に role ベースの認可を実装する (ADR 010 §4 §5)

### DIFF
--- a/apps/fumufumu-backend/src/index.ts
+++ b/apps/fumufumu-backend/src/index.ts
@@ -204,6 +204,12 @@ api.route('/users', userRoute);
 api.route('/tags', tagsRoute);
 
 // 投稿チェック運営API（/api/admin/content-check）
+//
+// 🛡 /api/admin/* 配下を追加する際の必須ルール (ADR 010 §4):
+//   controller 側の middleware chain に必ず `authGuard, adminGuard` をセットで適用すること。
+//   - adminGuard は authGuard が確定させた appUserId を前提とするため、必ずこの順序
+//   - 未認可時は 404 を返し、admin API の存在自体を露出させない方針
+//   - この規約はコード上強制されていない。将来の構造的強制は別 Issue で検討する。
 api.route('/admin/content-check', adminContentCheckRoute);
 
 // 通知内部API（/api/internal/notifications）

--- a/apps/fumufumu-backend/src/middlewares/adminGuard.middleware.ts
+++ b/apps/fumufumu-backend/src/middlewares/adminGuard.middleware.ts
@@ -1,0 +1,38 @@
+import { Next, Context } from 'hono';
+import { eq } from 'drizzle-orm';
+
+import { type Env, type Variables } from '../index';
+import { users } from '../db/schema/user';
+
+type AppContext = Context<{ Bindings: Env, Variables: Variables }>;
+
+/**
+ * 管理者権限ガード: users.role === 'admin' のみ通過させる
+ *
+ * 前提: 直前で authGuard が実行され、c.get('appUserId') が確定していること。
+ * 未認可時は 403 ではなく 404 を返す（admin API の存在自体を露出させないため）。
+ * 詳細は ADR 010 §4 を参照。
+ */
+export const adminGuard = async (c: AppContext, next: Next) => {
+  const appUserId = c.get('appUserId');
+  const db = c.get('db');
+
+  const user = await db.query.users.findFirst({
+    where: eq(users.id, appUserId),
+    columns: { role: true },
+  });
+
+  if (user?.role !== 'admin') {
+    // クライアントには 404 を返しつつ、サーバーログでは「権限不足」を区別可能にする。
+    // 運用上「自分が見れないのは権限不足？それとも本当に存在しない URL？」を切り分けるため。
+    // TODO: プロジェクト全体で構造化ロガーを導入した際は、このログもそちらに寄せる。
+    console.warn('adminGuard: access denied', {
+      appUserId,
+      role: user?.role ?? null,
+      path: c.req.path,
+    });
+    return c.json({ error: 'Not Found' }, 404);
+  }
+
+  await next();
+};

--- a/apps/fumufumu-backend/src/middlewares/adminGuard.middleware.ts
+++ b/apps/fumufumu-backend/src/middlewares/adminGuard.middleware.ts
@@ -29,6 +29,7 @@ export const adminGuard = async (c: AppContext, next: Next) => {
     console.warn('adminGuard: access denied', {
       appUserId,
       role: user?.role ?? null,
+      method: c.req.method,
       path: c.req.path,
     });
     return c.json({ error: 'Not Found' }, 404);

--- a/apps/fumufumu-backend/src/repositories/user.repository.ts
+++ b/apps/fumufumu-backend/src/repositories/user.repository.ts
@@ -22,6 +22,7 @@ export class UserRepository {
 				id: true,
 				name: true,
 				disabled: true,
+				role: true,
 				createdAt: true,
 				updatedAt: true,
 			},

--- a/apps/fumufumu-backend/src/routes/admin-content-check.controller.ts
+++ b/apps/fumufumu-backend/src/routes/admin-content-check.controller.ts
@@ -3,6 +3,7 @@ import { createFactory } from "hono/factory";
 import { zValidator } from "@hono/zod-validator";
 import type { AppBindings } from "@/index";
 import { authGuard } from "@/middlewares/authGuard.middleware";
+import { adminGuard } from "@/middlewares/adminGuard.middleware";
 import { injectConsultationContentCheckService } from "@/middlewares/injectService.middleware";
 import {
   listConsultationContentChecksQuerySchema,
@@ -96,7 +97,9 @@ const decideAdviceContentCheckHandlers = factory.createHandlers(
 
 export const adminContentCheckRoute = new Hono<AppBindings>();
 
-adminContentCheckRoute.use("/*", authGuard, injectConsultationContentCheckService);
+// ADR 010 §4: /api/admin/* 全体に authGuard → adminGuard を必須化する。
+// adminGuard は authGuard が確定させた appUserId を前提とするため、必ずこの順序。
+adminContentCheckRoute.use("/*", authGuard, adminGuard, injectConsultationContentCheckService);
 adminContentCheckRoute.get("/consultations", ...listConsultationContentChecksHandlers);
 adminContentCheckRoute.post("/consultations/:consultationId/decision", ...decideConsultationContentCheckHandlers);
 adminContentCheckRoute.get("/advices", ...listAdviceContentChecksHandlers);

--- a/apps/fumufumu-backend/src/services/user.service.ts
+++ b/apps/fumufumu-backend/src/services/user.service.ts
@@ -1,13 +1,18 @@
 // Business層: ユーザービジネスロジック
 import type { UserRepository } from "@/repositories/user.repository";
+import type { UserRole } from "@/db/schema/user";
 
 /**
  * ユーザー情報レスポンス型
+ *
+ * role はフロントエンドの admin layout guard / UI 出し分けで参照される（ADR 010 §5）。
+ * 自分自身の role を返すだけで他人の role は露出しない。
  */
 export interface UserResponse {
 	id: number;
 	name: string;
 	disabled: boolean;
+	role: UserRole;
 	createdAt: string;
 	updatedAt: string;
 }
@@ -25,6 +30,7 @@ export class UserService {
 		id: number;
 		name: string;
 		disabled: boolean;
+		role: UserRole;
 		createdAt: Date;
 		updatedAt: Date;
 	}): UserResponse {
@@ -32,6 +38,7 @@ export class UserService {
 			id: user.id,
 			name: user.name,
 			disabled: user.disabled,
+			role: user.role,
 			createdAt: user.createdAt.toISOString(),
 			updatedAt: user.updatedAt.toISOString(),
 		};

--- a/apps/fumufumu-backend/src/test/admin-guard.integration.test.ts
+++ b/apps/fumufumu-backend/src/test/admin-guard.integration.test.ts
@@ -1,0 +1,50 @@
+import { env } from 'cloudflare:test';
+import { beforeAll, describe, expect, it } from 'vitest';
+import app from '../index';
+import { setupIntegrationTest } from './helpers/db-helper';
+import { createAndLoginUser } from './helpers/auth-helper';
+import { createApiRequest } from './helpers/request-helper';
+
+/**
+ * adminGuard middleware の認可挙動を /api/admin/content-check 経由で検証する。
+ *
+ * ADR 010 §4:
+ *  - 認証済み非 admin は 404（403 ではない）を受け取る
+ *    → admin API の存在自体を露出させない
+ *  - 未認証は authGuard が先に 401 を返す（adminGuard まで到達しない）
+ *    → 既存の content-check テストでカバー済みのため本ファイルでは扱わない
+ */
+describe('adminGuard middleware', () => {
+  beforeAll(async () => {
+    await setupIntegrationTest();
+  });
+
+  it('認証済みでも role=user の場合は admin API に 404 を返す', async () => {
+    const regularUser = await createAndLoginUser();
+
+    const req = createApiRequest('/api/admin/content-check/consultations', 'GET', {
+      cookie: regularUser.cookie,
+      queryParams: { view: 'summary' },
+    });
+
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(404);
+
+    const data = await res.json() as { error: string };
+    expect(data.error).toBe('Not Found');
+  });
+
+  it('role=admin は admin API を 200 で通過できる', async () => {
+    const adminUser = await createAndLoginUser({ role: 'admin' });
+
+    const req = createApiRequest('/api/admin/content-check/consultations', 'GET', {
+      cookie: adminUser.cookie,
+      queryParams: { view: 'summary' },
+    });
+
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/fumufumu-backend/src/test/admin-guard.integration.test.ts
+++ b/apps/fumufumu-backend/src/test/admin-guard.integration.test.ts
@@ -47,4 +47,22 @@ describe('adminGuard middleware', () => {
 
     expect(res.status).toBe(200);
   });
+
+  it('POST 系 admin endpoint も非 admin は 404 を返す (method を問わず gate される)', async () => {
+    // GET だけテストすると「app.use('/*', ...) で本当に POST も拾えているか」が担保できないため、
+    // method 横断で gate が効くことを確認する。
+    const regularUser = await createAndLoginUser();
+
+    const req = createApiRequest('/api/admin/content-check/consultations/1/decision', 'POST', {
+      cookie: regularUser.cookie,
+      body: { decision: 'approved' },
+    });
+
+    const res = await app.fetch(req, env);
+
+    expect(res.status).toBe(404);
+
+    const data = await res.json() as { error: string };
+    expect(data.error).toBe('Not Found');
+  });
 });

--- a/apps/fumufumu-backend/src/test/consultations/content-check-advices.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/content-check-advices.test.ts
@@ -26,7 +26,8 @@ describe("Admin Content Check API - Advices", () => {
 
 	beforeAll(async () => {
 		await setupIntegrationTest();
-		user = await createAndLoginUser();
+		// user は admin 系エンドポイントを叩くため admin ロールで作成（ADR 010）。
+		user = await createAndLoginUser({ role: "admin" });
 
 		const tagName = `content-check-advice-tag-${Date.now()}`;
 		await env.DB.prepare("INSERT INTO tags (name) VALUES (?)").bind(tagName).run();

--- a/apps/fumufumu-backend/src/test/consultations/content-check-consultations.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/content-check-consultations.test.ts
@@ -13,7 +13,8 @@ describe('Admin Content Check API - Consultations', () => {
 
   beforeAll(async () => {
     await setupIntegrationTest();
-    user = await createAndLoginUser();
+    // user は admin 系エンドポイントを叩くため admin ロールで作成（ADR 010）。
+    user = await createAndLoginUser({ role: 'admin' });
     anotherUser = await createAndLoginUser();
 
     const tagName = `content-check-tag-${Date.now()}`;

--- a/apps/fumufumu-backend/src/test/helpers/auth-helper.ts
+++ b/apps/fumufumu-backend/src/test/helpers/auth-helper.ts
@@ -1,13 +1,18 @@
 import { env } from 'cloudflare:test';
 import app from '@/index';
+import type { UserRole } from '@/db/schema/user';
 
 /**
  * テスト用のユーザーを作成し、セッションCookieを返す
+ *
+ * role を 'admin' で渡した場合は、サインアップ後に users.role を直接 UPDATE する。
+ * ADR 010 の本番運用方針（DB 直 UPDATE のみで admin 付与）をテストでも再現する。
  */
-export async function createAndLoginUser(options?: { name?: string; email?: string }) {
+export async function createAndLoginUser(options?: { name?: string; email?: string; role?: UserRole }) {
   const name = options?.name ?? 'Test User';
   const email = options?.email ?? `test-${crypto.randomUUID()}@example.com`;
   const password = 'password123456';
+  const role: UserRole = options?.role ?? 'user';
 
   const signupReq = new Request('http://localhost/api/auth/signup', {
     method: 'POST',
@@ -31,11 +36,19 @@ export async function createAndLoginUser(options?: { name?: string; email?: stri
   // 属性を取り除き "key=value" の形だけ抽出
   const sessionCookie = setCookie.split(';')[0];
 
+  if (role !== 'user') {
+    await env.DB
+      .prepare('UPDATE users SET role = ? WHERE id = ?')
+      .bind(role, signupBody.app_user_id)
+      .run();
+  }
+
   return {
     cookie: sessionCookie,
     appUserId: signupBody.app_user_id,
     authUserId: signupBody.auth_user_id,
     email,
-    name
+    name,
+    role,
   };
 }

--- a/apps/fumufumu-backend/src/test/user.integration.test.ts
+++ b/apps/fumufumu-backend/src/test/user.integration.test.ts
@@ -40,8 +40,28 @@ describe('Consultations API Integration Tests', () => {
             const data = await res.json() as any;
             expect(data.name).equal('Test User for Consultations');
             expect(data.disabled).equal(false);
+            // 新規ユーザーはデフォルトで role = 'user'。フロント admin layout guard が参照する。
+            expect(data.role).equal('user');
             expect(data).toHaveProperty('createdAt');
             expect(data).toHaveProperty('updatedAt');
+        });
+
+        it('admin ロールのユーザーは role: "admin" が返る', async () => {
+            const admin = await createAndLoginUser({
+                name: 'Admin User',
+                email: `admin-me-${Date.now()}@example.com`,
+                role: 'admin',
+            });
+
+            const req = createApiRequest('/api/users/me', 'GET', {
+                cookie: admin.cookie,
+            });
+
+            const res = await app.fetch(req, env);
+            expect(res.status).toBe(200);
+
+            const data = await res.json() as any;
+            expect(data.role).equal('admin');
         });
 
 

--- a/apps/fumufumu-frontend/src/app/(main)/admin/layout.tsx
+++ b/apps/fumufumu-frontend/src/app/(main)/admin/layout.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+import { fetchCurrentUserApi } from "@/features/user/api/userApi";
+
+/**
+ * /admin/** の server-side 認可 guard (ADR 010 §5)
+ *
+ * - role !== 'admin' なら notFound() で 404 化する
+ *   → admin 画面の存在自体を一般ユーザーから露出させない
+ *   → バックエンドの adminGuard (/api/admin/* も 404 を返す) と挙動を揃える
+ * - 親 (main)/layout.tsx で未認証は /login にリダイレクト済みなので、
+ *   ここに到達する時点で「ログイン済みだが admin ではない」ケースのみ考慮すれば良い
+ * - fetchCurrentUserApi が null を返すケース (バックエンド到達不能・セッション失効など) も
+ *   保守的に notFound() に倒す
+ */
+export default async function AdminLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  const currentUser = await fetchCurrentUserApi();
+
+  if (currentUser?.role !== "admin") {
+    notFound();
+  }
+
+  return <>{children}</>;
+}

--- a/apps/fumufumu-frontend/src/features/user/types/index.ts
+++ b/apps/fumufumu-frontend/src/features/user/types/index.ts
@@ -1,7 +1,11 @@
+export const USER_ROLES = ["user", "admin"] as const;
+export type UserRole = (typeof USER_ROLES)[number];
+
 export interface User {
   id: number;
   name: string;
   disabled: boolean;
+  role: UserRole;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## 背景

ADR 010「管理画面（/admin）の権限制御 MVP 方針」を Accepted した直後、前 PR (`feature/admin-permissions`) で `users.role` 列を schema に追加してリモート D1 に反映済み。初期管理者の付与も DB 直 UPDATE で完了済み。

ただしこの時点では:

- バックエンド `/api/admin/content-check/*` は `authGuard`（ログイン済みかどうか）しか掛かっておらず、**ログインさえしていれば誰でも curl で投稿の承認/却下 API を叩ける状態** が残っていた
- 公開リポジトリのため admin 系エンドポイントの URL は grep で完全に把握できる前提
- フロントエンド `/admin` も `(main)/admin/page.tsx` のプレースホルダだけが置かれており、一般ユーザーからも到達可能だった

本 PR は ADR 010 §4 / §5 で決めた **バックエンド `adminGuard` と フロントエンド layout guard の実装** によって、上記のセキュリティ穴と画面露出を塞ぐ。

## このPRで解決すること

- `/api/admin/content-check/*` を **role=admin のユーザーのみ** が叩ける状態にする
- `/admin/**` を **role=admin のユーザーのみ** が server-side で開ける状態にする
- 非 admin に対しては、API もページも **404 を返す**（admin API/画面の存在自体を露出させない、ADR 010 §4 §5）
- 上記の認可挙動を CI で常時担保するテストを追加する

## 解決方法

### バックエンド: `adminGuard` middleware

- 新規 `apps/fumufumu-backend/src/middlewares/adminGuard.middleware.ts`
  - `authGuard` の後段で動く前提（`c.get('appUserId')` を読む）
  - `users.role` を引き、`'admin'` でなければ `404 + {"error": "Not Found"}` を返す
  - 同時に `console.warn` に `appUserId / role / method / path` を残し、運用上「権限不足」と「本当に存在しない URL」を切り分け可能にする
- `/api/admin/content-check/*` の controller に `authGuard, adminGuard` を順序固定で適用
- `src/index.ts` の `/admin` route 登録箇所に「**`/api/admin/*` 配下を追加する際は controller 側で adminGuard を必須適用すること**」コメントを残す（規約レベルの保証。構造的強制は別 Issue）

### バックエンド: `/api/users/me` 拡張

- フロント layout guard が「自分の role」を取得できるよう、`/api/users/me` のレスポンスに `role` を追加
- 自分自身の role を返すだけで他人の role は露出しない（情報漏洩にあたらない）

### フロントエンド: layout guard

- 新規 `apps/fumufumu-frontend/src/app/(main)/admin/layout.tsx`
  - Server Component で `fetchCurrentUserApi()` を呼び、`role !== 'admin'` なら `notFound()` で 404 化
  - `currentUser` が null（バックエンド到達不能・セッション失効）の場合も保守的に `notFound()`
  - 親 `(main)/layout.tsx` で未認証は `/login` リダイレクト済みのため、ここに到達するのは「ログイン済み非 admin」ケースのみ
- `User` 型に `role: UserRole` と `USER_ROLES` 定数を追加
- 全て Server Component で完結（CLAUDE.md の `useEffect` 既定禁止ルールと整合）

### テスト

- 新規 `admin-guard.integration.test.ts`:
  - 認証済み非 admin → 404 / `{ error: 'Not Found' }`
  - admin → 200
  - POST endpoint も非 admin は 404（`app.use('/*', ...)` が method を問わず gate）
- 既存 admin 系テスト 2 ファイル（`content-check-advices`, `content-check-consultations`）を admin role 前提に修正
- `createAndLoginUser` ヘルパに `role` オプションを追加し、signup 後に DB 直 UPDATE で admin 化（ADR 010 の本番付与経路をテストでも再現）

## API contract 変更（破壊性: 無し）

- `GET /api/users/me` のレスポンスに `role: 'user' | 'admin'` が追加される
- 既存 frontend consumer は新フィールドを単に無視するだけなので破壊は無いが、TypeScript 上では `User` 型の必須プロパティとなる
- 他言語クライアントや手書き mock を持つコード（存在しない）には影響なし

## このPRで意図的に含めていないこと

- **`/admin` UI の実機能**（ユーザー一覧、BAN フラグ切替、投稿チェック画面）— ADR 010 §1 のスコープではあるが、後続 PR
- **権限付与 API** — ADR 010 §3 で MVP では作らない決定（攻撃面を持ち込まない）
- **DB schema 変更 / migration 適用** — 前 PR (`feature/admin-permissions`) で完了済み
- **404 ページのデザイン整備 / `/admin` の `(main)` 外出し** — 外形上の admin 露出を更に抑える件、別 Issue 化済み
- **`/api/admin/*` への adminGuard 必須化の構造的強制** — controller 側の規約頼みは弱い。別 Issue 化済み
- **`users.disabled` の認証/認可での enforce** — pre-existing な穴を本 PR セルフレビュー時に発見。本 PR 由来ではないため別 Issue 化済み。BAN 機能を実装する後続 PR の前提となる

## 動作確認

### 自動テスト

- backend: 16 ファイル / 168 tests pass（前 baseline +4: admin-guard 新規 3 + /me role 1）
- frontend: 既存 2 tests pass、biome lint clean、`tsc --noEmit` は worker.ts の既存警告のみで新規エラーなし

### 実機（ローカル）

- 一般ユーザーで `/admin` 直打ち → 404
- admin ユーザーで `/admin` 直打ち → プレースホルダ「管理画面（仮）」表示
- 一般ユーザーで `curl -b <cookie> /api/admin/content-check/consultations` → `404 {"error":"Not Found"}`
- 一般ユーザーで `curl -b <cookie> /api/admin/content-check/consultations/1/decision -X POST` → `404`（method 問わず gate）
- 未認証で `/api/admin/...` → `401`（authGuard が先に弾く）

## レビュー時に見てほしい点

- ADR 010 §4 で決めた「未認可は 403 ではなく 404」の表現が API / フロント / テストで一貫しているか
- `adminGuard` を `authGuard` の後段に強制する依存（`c.get('appUserId')` 前提）が、配線時に守られる規約として十分か（構造的強制は別 Issue だが、本 PR の規約コメントが過不足ないか）
- `/api/users/me` のレスポンスに `role` を含める設計の妥当性（自分自身の role を返すだけ）
- Frontend layout guard が `currentUser == null` を保守的に notFound() に倒す挙動でセッション失効時 UX が許容範囲か

## 関連

- ADR: [`docs/design/adr/010-admin-permissions-mvp.md`](docs/design/adr/010-admin-permissions-mvp.md) §4 §5
- 前 PR: `feature/admin-permissions`（DB schema 追加 + 初期管理者付与）
- 後続 Issue:
  - `/admin` UI の実機能実装（ユーザー一覧 / BAN / 投稿チェック画面）
  - 404 ページ整備 + /admin の (main) 外出し
  - /api/admin/* への adminGuard 必須化の構造的強制
  - users.disabled の認証/認可 enforce（BAN 機能の前提）
  - pnpm typecheck script 導入