### PR TITLE
🔨chore(infra): wrangler compatibility_date を bump し frontend README をデプロイ runbook 中心に書き換え

### DIFF
--- a/apps/fumufumu-backend/wrangler.jsonc
+++ b/apps/fumufumu-backend/wrangler.jsonc
@@ -3,7 +3,7 @@
   "account_id": "YOUR_CLOUDFLARE_ACCOUNT_ID",
   "name": "your-worker-name",
   "main": "src/index.ts",
-  "compatibility_date": "2025-10-26",
+  "compatibility_date": "2026-06-07",
   "dev": {
     "ip": "127.0.0.1",
     "port": 8787,

--- a/apps/fumufumu-backend/wrangler.local.jsonc.example
+++ b/apps/fumufumu-backend/wrangler.local.jsonc.example
@@ -3,7 +3,7 @@
   "account_id": "YOUR_CLOUDFLARE_ACCOUNT_ID",
   "name": "your-worker-name",
   "main": "src/index.ts",
-  "compatibility_date": "2025-10-26",
+  "compatibility_date": "2026-06-07",
   "dev": {
     "ip": "127.0.0.1",
     "port": 8787,

--- a/apps/fumufumu-frontend/README.md
+++ b/apps/fumufumu-frontend/README.md
@@ -1,31 +1,106 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+## 現在の production 環境
 
-## Getting Started
+- Worker URL: `https://fumufumu-frontend.fumufumu.workers.dev`
+- backend (`fumufumu-worker`) を **Service Binding 経由** で同一 origin として扱う構成（ADR 008 §4.6 / PR #128）。`worker.ts` の custom worker が `/api/*` を `env.BACKEND.fetch(...)` に振り分け、それ以外を OpenNext (Next.js) でレンダリングする。
+- Cloudflare account / Worker 名 / Service Binding (`services` セクション) 等は git ignored の `wrangler.local.jsonc` で管理（リポジトリには `wrangler.local.jsonc.example` のみ）。
+- Cloudflare plan: Free。
 
-First, run the development server:
+本書中の `<frontend-production-url>` プレースホルダーは上記 URL を指す（custom domain 移行時に置き換える）。
+
+## コマンド集
+
+- ローカル開発起動: `pnpm dev`
+- lint: `pnpm lint`（biome）
+- format: `pnpm format`（biome、書き込みあり）
+- ユニットテスト: `pnpm test` / `pnpm test:watch`
+- Next.js ビルド: `pnpm build`
+- Cloudflare 用ビルド (OpenNext 経由): `pnpm build:cf`
+- 手動デプロイ: `DEPLOY_APPROVED=1 pnpm deploy:cf`
+
+`pnpm deploy:cf` は内部で `build:cf` → `wrangler deploy` を順に実行する。`DEPLOY_APPROVED=1` を実行時に明示しない場合は誤実行防止 guard で中断する。
+
+## デプロイ runbook (production)
+
+frontend の本番 deploy は GitHub Actions に内包せず、手動で独立実行する（ADR 008 / 計画書 07）。実行対象 Worker は `--config` で指定した設定ファイル内の `name` で決定する。
+
+### 事前準備
 
 ```bash
-# or
-pnpm dev
+cd apps/fumufumu-frontend
+cp wrangler.local.jsonc.example wrangler.local.jsonc
+# wrangler.local.jsonc に account_id / name / services (Service Binding) を設定
+cp .env.production.local.example .env.production.local
+# .env.production.local の NEXT_PUBLIC_API_URL を frontend Worker の絶対 URL に設定
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+`.env.production.local` の用途と命名理由は当該テンプレートのコメントを参照（Next.js の env loading 順の都合で `.local` 系を使う）。`NEXT_PUBLIC_*` は build 時に client side bundle へ inline されるため、Cloudflare 側の `vars` / secrets ではなくここで解決する。
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+必要に応じて設定ファイルを切り替える:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+# デフォルト: wrangler.local.jsonc
+export WRANGLER_DEPLOY_CONFIG=wrangler.local.jsonc
 
-## Learn More
+# 例: CI で生成した設定ファイルを使う場合
+export WRANGLER_DEPLOY_CONFIG=wrangler.ci.jsonc
+```
 
-To learn more about Next.js, take a look at the following resources:
+### 実行
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+DEPLOY_APPROVED=1 pnpm deploy:cf
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+成功時の主な確認ポイント:
 
-## Deploy on Vercel
+- `Worker saved in .open-next/worker.js` が出ていること（OpenNext bundle が生成済み）
+- `Uploaded fumufumu-frontend (...)` が出ていること（wrangler の upload 完了）
+- `Deployed fumufumu-frontend triggers (...)` が出ていること
+- 末尾に `https://<frontend-production-url>` と `Current Version ID: ...` が表示されること
+- `env.BACKEND (fumufumu-worker)` が Bindings に列挙されていること（Service Binding 維持）
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+### 適用後確認（例）
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+# 未認証 = LP / 公開ページが 200 で返る
+curl -fS -I https://<frontend-production-url>/
+
+# SSR 経由の API proxy 動作（バックエンドが reachable か）
+curl -fS -I https://<frontend-production-url>/api/health || true
+```
+
+ログイン後の SSR 経路の動作確認はブラウザで `/consultations` 等を開いて行う（Cookie が必要なため）。
+
+## 環境変数
+
+### local development (`.env.local`)
+
+`.env.local.example` をコピーして使う:
+
+- `NEXT_PUBLIC_API_URL`: local backend の URL（既定 `http://localhost:8787`）
+- `USE_MOCK_API`: モック API 切り替え用フラグ（既定 `false`）
+
+### production build (`.env.production.local`)
+
+`.env.production.local.example` をコピーして使う:
+
+- `NEXT_PUBLIC_API_URL`: **frontend Worker 自身の絶対 URL**（Service Binding 経由で同一 origin になるため）
+
+「同一 origin なら相対パスでよいのでは」と思いがちだが、SSR (Cloudflare Workers) は相対パスの fetch を受け付けず Worker が crash する。client side では同一 origin なので CORS は発生しない。詳細は `worker.ts` / `lib/api/client.ts` のコメントを参照。
+
+### Cloudflare 側 vars / secrets
+
+frontend Worker では現状 `vars` / `secrets` は使用していない（`NEXT_PUBLIC_*` は build 時 inline）。将来サーバー側の機密が必要になったら `wrangler secret put` で管理する。
+
+## 補足
+
+- pnpm 10 以降は `pnpm deploy` が pnpm 内蔵のモノレポ deploy コマンドと衝突するため、frontend では明示的に `pnpm deploy:cf` script 名にしている（衝突回避）。
+- `WRANGLER_DEPLOY_CONFIG` が未設定の場合、`pnpm deploy:cf` は `wrangler.local.jsonc` を参照する。
+- OpenNext のビルド成果物 (`.open-next/`) は git ignored。`pnpm build:cf` で都度生成される。
+- `worker.ts` (custom worker) は OpenNext の generated worker をラップして `/api/*` を Service Binding に振り分けるためのもの。詳細は同ファイル冒頭のコメントを参照。
+
+## 関連ドキュメント
+
+- ADR: [`docs/design/adr/008-frontend-deployment-platform-and-split-cicd.md`](../../docs/design/adr/008-frontend-deployment-platform-and-split-cicd.md)
+- 計画書: [`docs/projects/07-cicd-and-deployment.md`](../../docs/projects/07-cicd-and-deployment.md)
+- backend 側 runbook: [`apps/fumufumu-backend/README.md`](../fumufumu-backend/README.md)

--- a/apps/fumufumu-frontend/wrangler.jsonc
+++ b/apps/fumufumu-frontend/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "fumufumu-frontend",
   "main": "./worker.ts",
-  "compatibility_date": "2025-10-26",
+  "compatibility_date": "2026-06-07",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "assets": {
     "directory": ".open-next/assets",

--- a/apps/fumufumu-frontend/wrangler.local.jsonc.example
+++ b/apps/fumufumu-frontend/wrangler.local.jsonc.example
@@ -25,7 +25,7 @@
   "account_id": "YOUR_CLOUDFLARE_ACCOUNT_ID",
   "name": "fumufumu-frontend",
   "main": "./worker.ts",
-  "compatibility_date": "2025-10-26",
+  "compatibility_date": "2026-06-07",
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "assets": {
     "directory": ".open-next/assets",


### PR DESCRIPTION
## 背景

直近 (`feature/admin-guard`) の frontend deploy 時に、以下 2 つのメンテ課題が顕在化した:

### 1. wrangler compatibility_date が古い

```
WARN workerd compatibility_date: 2025-10-26, consider updating your wrangler config to a more recent date
```

backend / frontend ともに `2025-10-26` のままで、wrangler が新しめへの更新を推奨していた。`compatibility_date` は Cloudflare Workers runtime の機能フラグセットを固定するもので、古いと最新機能 / バグ修正の恩恵を受けにくい。

### 2. frontend の README にデプロイ手順が無い

`apps/fumufumu-frontend/README.md` が `create-next-app` の boilerplate のままで、唯一のデプロイ案内が "Deploy on Vercel" セクション。ADR 008 で Cloudflare workers.dev に移行済みのため完全に stale。手動 deploy のコマンドが README から読み取れない状態だった。

一方 `apps/fumufumu-backend/README.md` は production 環境 / コマンド集 / deploy runbook / migration runbook 等が整備済みで非対称な状態。

## このPRで解決すること

- 4 ファイルの `compatibility_date` を `2025-10-26` → `2026-06-07` に bump し、wrangler の WARN を解消する
- frontend README を backend と対称な構造に全面書き換えし、手動 deploy 手順を README から読み取れる状態にする

## 含まれる変更

| 変更 | 内容 |
|---|---|
| `apps/fumufumu-backend/wrangler.jsonc` | `compatibility_date` を `2026-06-07` に更新 |
| `apps/fumufumu-backend/wrangler.local.jsonc.example` | 同上（運用者がコピーする雛形側も揃える） |
| `apps/fumufumu-frontend/wrangler.jsonc` | 同上 |
| `apps/fumufumu-frontend/wrangler.local.jsonc.example` | 同上 |
| `apps/fumufumu-frontend/README.md` | create-next-app boilerplate を全削除し、backend README と同じ構成に書き換え（現在の production 環境 / コマンド集 / デプロイ runbook / 環境変数 / 補足 / 関連ドキュメント） |

## 日付の選定

`compatibility_date` の値は本日 (`2026-06-07`) を採用。

- 直近すぎる日付は未テストの runtime 挙動変更を踏むリスクがあるが、ローカル / production 双方で動作確認できるタイミングのため許容
- 古すぎる日付は最新機能の恩恵を受けにくく、半年単位で同じ作業を繰り返すことになるため避けたい

## このPRで意図的に含めていないこと

- **backend README の改修**: 既に runbook 整備済みのため触らない
- **CI ワークフロー上での自動デプロイ化**: 計画書 07 の Phase 1b 以降で扱う
- **`.env.production.local` の値の書き換え**: 個別環境固有のためテンプレートに記載するのみ
- **wrangler 4.94 → 4.98 等の wrangler バージョン更新**: 別 Issue / 別 PR にすべきスコープ

## 動作確認

### compat-date bump

- backend: ローカル開発 (`pnpm dev`) と vitest 全 168 件 pass を確認（本 PR では touch していないが、wrangler config 読み込み経路に影響しないこと）
- frontend: ローカル開発 / `pnpm build` / `pnpm build:cf` で warn 消失を確認したい（マージ後の deploy 時にも検証）

### README

- backend README と章立てが対称（現在の production 環境 / コマンド集 / runbook / 環境変数 / 補足）
- 手動 deploy コマンド (`DEPLOY_APPROVED=1 pnpm deploy:cf`) が冒頭の「コマンド集」と「デプロイ runbook」の両方から到達可能
- Service Binding 経路の説明と `.env.production.local` 命名理由を、テンプレートのコメントと重複しない形で参照

## 関連

- ADR: [`docs/design/adr/008-frontend-deployment-platform-and-split-cicd.md`](docs/design/adr/008-frontend-deployment-platform-and-split-cicd.md)
- 計画書: [`docs/projects/07-cicd-and-deployment.md`](docs/projects/07-cicd-and-deployment.md)
- 関連 Issue: 「frontend README にデプロイ手順書を追加する」（本 PR で close）
- 発覚経緯: feature/admin-guard ブランチ deploy 時に wrangler の WARN とデプロイコマンド不明を同時に確認