### PR TITLE
👷ci: GitHub Actions の Node.js 20 deprecation に追従し actions / setup-node 系を Node 24 化

### DIFF
--- a/.github/workflows/be-health-check-ci.yml
+++ b/.github/workflows/be-health-check-ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install jq
       run: sudo apt-get update && sudo apt-get install -y jq

--- a/.github/workflows/be-test.yml
+++ b/.github/workflows/be-test.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
           run_install: false

--- a/.github/workflows/fe-code-check.yml
+++ b/.github/workflows/fe-code-check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js and pnpm
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       
       - name: Enable pnpm via Corepack
         # Node.js がインストールされている環境で pnpm を有効化

--- a/.github/workflows/fe-code-check.yml
+++ b/.github/workflows/fe-code-check.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup Node.js and pnpm
         uses: actions/setup-node@v6


### PR DESCRIPTION
## 背景

GitHub Actions runner が Node.js 20 を deprecate する schedule をアナウンスしている:

- **2026-06-16**: default runner が Node.js 24 に切り替わる
- **2026-09-16**: Node.js 20 を runner から完全削除

参考: [GitHub Changelog — Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

直近の PR Annotations に以下の警告が出始めていた:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4 ...

今日 (2026-06-07) 時点で default 切替まで 9 日、完全削除まで 約 3 ヶ月。本 PR で先回り対応する。

## このPRで解決すること

- GitHub Actions の **action runtime** 側で Node 20 を使っているものを全て排除する
- 同じ workflow 系列で残っていた **build 実行 Node** 側の Node 20 も同時に Node 24 化する（同根の問題なので一緒に処理）
- 結果として、リポジトリの CI からは Node 20 が完全に消える状態にする

## 含まれる変更

### Action runtime の bump（commit `88e174e`）

| File | 変更 | 理由 |
|---|---|---|
| `.github/workflows/fe-code-check.yml` | `actions/checkout@v4` → `@v6` | v4 が internal Node 20、v5+ で Node 24 化 |
| `.github/workflows/be-health-check-ci.yml` | `actions/checkout@v4` → `@v6` | 同上 |
| `.github/workflows/be-test.yml` | `actions/checkout@v4` → `@v6` | 同上 |
| `.github/workflows/be-test.yml` | `pnpm/action-setup@v4` → `@v6` | `v4/action.yml` が `using: "node20"` のまま（直接確認済み）。v5+ で Node 24 化 |

### Build 実行 Node の bump（commit `03c4cb9`）

| File | 変更 | 理由 |
|---|---|---|
| `.github/workflows/fe-code-check.yml` | `node-version: 20` → `24` | backend workflow (be-health-check-ci / be-test) が既に `node-version: 24` で動いており frontend だけ外れていた。Node 20 は 2026-04 で EOL |

### 変更しないもの

- `actions/setup-node@v6` — 既に最新 major
- `biomejs/setup-biome@v2` — v2.7.1 (2026-03-11) で内部的に Node 24 化済み。v2 major のまま
- `apps/fumufumu-frontend/package.json` の `engines.node` — `>=20.0.0` のまま（24 と互換のため bump 不要、ローカル開発環境に過度な制約を課さない方針）

## 公式ドキュメントで確認した互換性事項

- **`actions/checkout@v6`** の minimum runner version は `v2.327.1`。GitHub-hosted runner は自動更新されるため影響なし。v6 の breaking change は「credential を `.git/config` ではなく `$RUNNER_TEMP` 配下の別ファイルに保存」のみで、workflow 側の変更は不要（`git fetch` / `git push` 等は引き続き動く）
- **`pnpm/action-setup@v6`** は pnpm v11 サポートを **追加** しただけで、v10 は引き続き利用可能。本 repo は pnpm 10.33.2 fixed のため影響なし
- **Next.js 16** は Node 22 / 24 を公式サポート

## このPRで意図的に含めていないこと

- `apps/fumufumu-frontend/package.json` の `engines.node` の引き上げ — ローカル開発に過度な制約を課さないため
- third-party action 全般の version 監査 — 警告対象（checkout）以外は別 PR / Dependabot 等で扱う想定
- CI workflow ロジック自体の改善（`/health` リトライ化など）— 別 Issue で進行中

## 動作確認

- CI が **all green** で通ること
- PR Annotations から **Node.js 20 deprecation 警告が消える** こと（commit `88e174e` の効果）

ローカルで GitHub Actions を実行する手段は無いため、本 PR の CI 結果で検証する。

## 関連

- 元 Issue: 「GitHub Actions の Node.js 20 deprecation に追従し actions/checkout を v5 に上げる」（本 PR で close。実調査で v5 ではなく v6 が現行 major、対象も pnpm/action-setup に拡大、で進めている）
- 関連 Changelog: [Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)
- 直近 merged PR: chore(infra) wrangler compatibility_date bump + frontend README runbook 整備