### PR TITLE
✨feat(admin): /admin に pending な相談・アドバイスの投稿チェック一覧を実装する

### DIFF
--- a/apps/fumufumu-frontend/src/app/(main)/admin/page.tsx
+++ b/apps/fumufumu-frontend/src/app/(main)/admin/page.tsx
@@ -1,8 +1,56 @@
-export default function AdminPage() {
+import {
+  fetchPendingAdvicesApi,
+  fetchPendingConsultationsApi,
+} from "@/features/admin-content-check/api/adminContentCheckApi";
+import { PendingAdviceList } from "@/features/admin-content-check/components/PendingAdviceList";
+import { PendingConsultationList } from "@/features/admin-content-check/components/PendingConsultationList";
+
+/**
+ * /admin トップ: 投稿チェック一覧 (Server Component)
+ *
+ * 設計:
+ *  - 相談 / アドバイスの 2 セクションを縦並びで表示 (plan §5.2、レイアウト案 A-1)
+ *  - Promise.allSettled で並列取得し、片方失敗しても他方は表示する (plan §5.3)
+ *  - 認可は親 layout (admin/layout.tsx) の role guard で済んでいるため本ページでは扱わない
+ */
+export default async function AdminPage() {
+  const [consultationsResult, advicesResult] = await Promise.allSettled([
+    fetchPendingConsultationsApi(),
+    fetchPendingAdvicesApi(),
+  ]);
+
   return (
-    <div className="max-w-4xl mx-auto w-full">
-      <h1 className="text-2xl font-bold">Admin</h1>
-      <p className="mt-4">管理画面（仮）</p>
+    <div className="mx-auto w-full max-w-4xl space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold text-gray-900">投稿チェック</h1>
+        <p className="mt-1 text-sm text-gray-600">
+          承認待ちの投稿を確認してください
+        </p>
+      </header>
+
+      <PendingConsultationList
+        {...(consultationsResult.status === "fulfilled"
+          ? { status: "success" as const, items: consultationsResult.value }
+          : {
+              status: "error" as const,
+              message: toErrorMessage(consultationsResult.reason),
+            })}
+      />
+
+      <PendingAdviceList
+        {...(advicesResult.status === "fulfilled"
+          ? { status: "success" as const, items: advicesResult.value }
+          : {
+              status: "error" as const,
+              message: toErrorMessage(advicesResult.reason),
+            })}
+      />
     </div>
   );
 }
+
+/** Promise rejection の reason を表示用文字列に変換する */
+const toErrorMessage = (reason: unknown): string => {
+  if (reason instanceof Error) return reason.message;
+  return "不明なエラーが発生しました";
+};

--- a/apps/fumufumu-frontend/src/app/(main)/admin/page.tsx
+++ b/apps/fumufumu-frontend/src/app/(main)/admin/page.tsx
@@ -9,8 +9,8 @@ import { PendingConsultationList } from "@/features/admin-content-check/componen
  * /admin トップ: 投稿チェック一覧 (Server Component)
  *
  * 設計:
- *  - 相談 / アドバイスの 2 セクションを縦並びで表示 (plan §5.2、レイアウト案 A-1)
- *  - Promise.allSettled で並列取得し、片方失敗しても他方は表示する (plan §5.3)
+ *  - 相談 / アドバイスの 2 セクションを縦並びで表示 (docs/projects/08 §5.2、レイアウト案 A-1)
+ *  - Promise.allSettled で並列取得し、片方失敗しても他方は表示する (docs/projects/08 §5.3)
  *  - 認可は親 layout (admin/layout.tsx) の role guard で済んでいるため本ページでは扱わない
  */
 export default async function AdminPage() {
@@ -18,6 +18,9 @@ export default async function AdminPage() {
     fetchPendingConsultationsApi(),
     fetchPendingAdvicesApi(),
   ]);
+
+  const consultationsProps = toListProps(consultationsResult);
+  const advicesProps = toListProps(advicesResult);
 
   return (
     <div className="mx-auto w-full max-w-4xl space-y-6">
@@ -28,26 +31,24 @@ export default async function AdminPage() {
         </p>
       </header>
 
-      <PendingConsultationList
-        {...(consultationsResult.status === "fulfilled"
-          ? { status: "success" as const, items: consultationsResult.value }
-          : {
-              status: "error" as const,
-              message: toErrorMessage(consultationsResult.reason),
-            })}
-      />
+      <PendingConsultationList {...consultationsProps} />
 
-      <PendingAdviceList
-        {...(advicesResult.status === "fulfilled"
-          ? { status: "success" as const, items: advicesResult.value }
-          : {
-              status: "error" as const,
-              message: toErrorMessage(advicesResult.reason),
-            })}
-      />
+      <PendingAdviceList {...advicesProps} />
     </div>
   );
 }
+
+/**
+ * PromiseSettledResult を list component の Props 型 (success / error の discriminated union)
+ * に変換する。相談 / アドバイス の 2 list component が同じ Props shape を共有しているため
+ * generic で 1 箇所にまとめている。
+ */
+const toListProps = <T,>(result: PromiseSettledResult<T[]>) => {
+  if (result.status === "fulfilled") {
+    return { status: "success" as const, items: result.value };
+  }
+  return { status: "error" as const, message: toErrorMessage(result.reason) };
+};
 
 /** Promise rejection の reason を表示用文字列に変換する */
 const toErrorMessage = (reason: unknown): string => {

--- a/apps/fumufumu-frontend/src/features/admin-content-check/api/adminContentCheckApi.ts
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/api/adminContentCheckApi.ts
@@ -1,0 +1,81 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { apiClient } from "@/lib/api/client";
+import type {
+  PendingAdviceDetail,
+  PendingAdviceDetailResponse,
+  PendingAdviceListResponse,
+  PendingConsultationDetail,
+  PendingConsultationDetailResponse,
+  PendingConsultationListResponse,
+} from "../types";
+
+/**
+ * pending な相談を取得する (server-only)
+ *
+ * 既存 admin API が summary（id だけ軽量に返す）と detail（title/body 等を含む）に
+ * 分かれているため、本関数で 2-call を内包し UI 表示に必要な詳細配列を返す。
+ *
+ * 並び順は backend の summary が `content_checks.created_at` 昇順を返すが、
+ * detail call は順序を保証しないため、本関数で summary の id 順に並べ直す。
+ */
+export async function fetchPendingConsultationsApi(): Promise<
+  PendingConsultationDetail[]
+> {
+  const cookieStore = await cookies();
+  const headers = { Cookie: cookieStore.toString() };
+
+  const summary = await apiClient<PendingConsultationListResponse>(
+    "/api/admin/content-check/consultations?view=summary",
+    { method: "GET", headers, cache: "no-store" },
+  );
+
+  const orderedIds = summary.consultations.map((c) => c.id);
+  if (orderedIds.length === 0) {
+    return [];
+  }
+
+  const detail = await apiClient<PendingConsultationDetailResponse>(
+    `/api/admin/content-check/consultations?view=detail&ids=${orderedIds.join(",")}`,
+    { method: "GET", headers, cache: "no-store" },
+  );
+
+  // detail の missing_ids / non_pending は同時操作（別 admin が直前に承認/却下）時に
+  // 起きうるが、MVP では UI 側で扱わずそのまま欠落させる。運用上は次回再読込で解消する。
+  const byId = new Map(detail.consultations.map((c) => [c.id, c]));
+  return orderedIds.flatMap((id) => {
+    const item = byId.get(id);
+    return item ? [item] : [];
+  });
+}
+
+/**
+ * pending なアドバイスを取得する (server-only)
+ *
+ * fetchPendingConsultationsApi と同じ 2-call パターン。
+ */
+export async function fetchPendingAdvicesApi(): Promise<PendingAdviceDetail[]> {
+  const cookieStore = await cookies();
+  const headers = { Cookie: cookieStore.toString() };
+
+  const summary = await apiClient<PendingAdviceListResponse>(
+    "/api/admin/content-check/advices?view=summary",
+    { method: "GET", headers, cache: "no-store" },
+  );
+
+  const orderedIds = summary.advices.map((a) => a.id);
+  if (orderedIds.length === 0) {
+    return [];
+  }
+
+  const detail = await apiClient<PendingAdviceDetailResponse>(
+    `/api/admin/content-check/advices?view=detail&ids=${orderedIds.join(",")}`,
+    { method: "GET", headers, cache: "no-store" },
+  );
+
+  const byId = new Map(detail.advices.map((a) => [a.id, a]));
+  return orderedIds.flatMap((id) => {
+    const item = byId.get(id);
+    return item ? [item] : [];
+  });
+}

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingAdviceList.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingAdviceList.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { PendingAdviceDetail } from "../types";
+import { PendingAdviceList } from "./PendingAdviceList";
+
+const sampleItem = (
+  overrides?: Partial<PendingAdviceDetail>,
+): PendingAdviceDetail => ({
+  id: 1,
+  consultation_id: 99,
+  body: "サンプルアドバイス本文",
+  author_id: 10,
+  status: "pending",
+  created_at: "2026-01-15T10:00:00Z",
+  ...overrides,
+});
+
+describe("PendingAdviceList", () => {
+  it("status=success かつ items があると件数バッジと各 card が出る", () => {
+    const items = [
+      sampleItem({ id: 1, body: "アドバイス本文 A" }),
+      sampleItem({ id: 2, body: "アドバイス本文 B" }),
+    ];
+    render(<PendingAdviceList status="success" items={items} />);
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "アドバイス" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/（2 件）/)).toBeInTheDocument();
+    expect(screen.getByText("アドバイス本文 A")).toBeInTheDocument();
+    expect(screen.getByText("アドバイス本文 B")).toBeInTheDocument();
+  });
+
+  it("status=success かつ items が空だと空状態メッセージが出る", () => {
+    render(<PendingAdviceList status="success" items={[]} />);
+
+    expect(screen.getByText(/（0 件）/)).toBeInTheDocument();
+    expect(
+      screen.getByText("チェック待ちのアドバイスはありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("status=error だと件数バッジは出ず、エラーメッセージと詳細が出る", () => {
+    render(
+      <PendingAdviceList
+        status="error"
+        message="サーバーが応答しませんでした"
+      />,
+    );
+
+    expect(screen.queryByText(/件）/)).toBeNull();
+
+    const alert = screen.getByRole("alert");
+    expect(
+      within(alert).getByText("アドバイスの取得に失敗しました"),
+    ).toBeInTheDocument();
+    expect(
+      within(alert).getByText("サーバーが応答しませんでした"),
+    ).toBeInTheDocument();
+  });
+
+  it("各アイテムに所属相談 ID への link が target='_blank' で出る", () => {
+    const items = [sampleItem({ id: 5, consultation_id: 42 })];
+    render(<PendingAdviceList status="success" items={items} />);
+
+    const link = screen.getByRole("link", { name: "#42" });
+    expect(link).toHaveAttribute("href", "/consultations/42");
+    expect(link).toHaveAttribute("target", "_blank");
+    // 別タブを安全に開くため noopener / noreferrer も付いていること
+    expect(link.getAttribute("rel")).toMatch(/noopener/);
+    expect(link.getAttribute("rel")).toMatch(/noreferrer/);
+  });
+});

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingAdviceList.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingAdviceList.tsx
@@ -1,0 +1,77 @@
+import type { PendingAdviceDetail } from "../types";
+import { PendingItemCard } from "./PendingItemCard";
+
+/**
+ * pending アドバイスのセクション (Server Component)
+ *
+ * 構造は PendingConsultationList と対称。所属相談のタイトル取得は API 拡張待ちのため、
+ * consultation_id のみカード末尾に表示する (docs/projects/08 §4.3)。
+ */
+type Props =
+  | {
+      status: "success";
+      items: PendingAdviceDetail[];
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+export const PendingAdviceList = (props: Props) => {
+  const count = props.status === "success" ? props.items.length : null;
+
+  return (
+    <section className="space-y-3">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-lg font-bold text-gray-900">アドバイス</h2>
+        {count !== null && (
+          <span className="text-sm text-gray-500">（{count} 件）</span>
+        )}
+      </header>
+
+      {props.status === "error" && (
+        <div
+          className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          role="alert"
+        >
+          <p>アドバイスの取得に失敗しました</p>
+          <p className="mt-1 text-xs text-red-500">{props.message}</p>
+        </div>
+      )}
+
+      {props.status === "success" && props.items.length === 0 && (
+        <p className="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-500">
+          チェック待ちのアドバイスはありません
+        </p>
+      )}
+
+      {props.status === "success" && props.items.length > 0 && (
+        <ul className="space-y-3">
+          {props.items.map((item) => (
+            <li key={item.id}>
+              <PendingItemCard
+                id={item.id}
+                body={item.body}
+                authorId={item.author_id}
+                createdAt={item.created_at}
+                meta={
+                  <span>
+                    所属相談:{" "}
+                    <a
+                      href={`/consultations/${item.consultation_id}`}
+                      target="_blank"
+                      rel="noreferrer noopener"
+                      className="text-teal-600 underline hover:text-teal-800"
+                    >
+                      #{item.consultation_id}
+                    </a>
+                  </span>
+                }
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { PendingConsultationDetail } from "../types";
+import { PendingConsultationList } from "./PendingConsultationList";
+
+const sampleItem = (
+  overrides?: Partial<PendingConsultationDetail>,
+): PendingConsultationDetail => ({
+  id: 1,
+  title: "サンプル相談",
+  body: "サンプル本文",
+  author_id: 10,
+  status: "pending",
+  created_at: "2026-01-15T10:00:00Z",
+  ...overrides,
+});
+
+describe("PendingConsultationList", () => {
+  it("status=success かつ items があると件数バッジと各 card が出る", () => {
+    const items = [
+      sampleItem({ id: 1, title: "相談A" }),
+      sampleItem({ id: 2, title: "相談B" }),
+    ];
+    render(<PendingConsultationList status="success" items={items} />);
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "相談" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/（2 件）/)).toBeInTheDocument();
+    expect(screen.getByText("相談A")).toBeInTheDocument();
+    expect(screen.getByText("相談B")).toBeInTheDocument();
+  });
+
+  it("status=success かつ items が空だと空状態メッセージが出る", () => {
+    render(<PendingConsultationList status="success" items={[]} />);
+
+    expect(screen.getByText(/（0 件）/)).toBeInTheDocument();
+    expect(
+      screen.getByText("チェック待ちの相談はありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("status=error だと件数バッジは出ず、エラーメッセージと詳細が出る", () => {
+    render(
+      <PendingConsultationList
+        status="error"
+        message="サーバーが応答しませんでした"
+      />,
+    );
+
+    // 件数バッジ「（N 件）」は出ない
+    expect(screen.queryByText(/件）/)).toBeNull();
+
+    const alert = screen.getByRole("alert");
+    expect(
+      within(alert).getByText("相談の取得に失敗しました"),
+    ).toBeInTheDocument();
+    expect(
+      within(alert).getByText("サーバーが応答しませんでした"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.tsx
@@ -5,7 +5,7 @@ import { PendingItemCard } from "./PendingItemCard";
  * pending 相談のセクション (Server Component)
  *
  * page.tsx 側で Promise.allSettled の結果を unwrap し、成功 / 失敗を本 component に渡す。
- * これにより、アドバイス側が失敗しても本セクションは正常に表示できる (plan §5.3)。
+ * これにより、アドバイス側が失敗しても本セクションは正常に表示できる (docs/projects/08 §5.3)。
  */
 type Props =
   | {

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.tsx
@@ -1,0 +1,65 @@
+import type { PendingConsultationDetail } from "../types";
+import { PendingItemCard } from "./PendingItemCard";
+
+/**
+ * pending 相談のセクション (Server Component)
+ *
+ * page.tsx 側で Promise.allSettled の結果を unwrap し、成功 / 失敗を本 component に渡す。
+ * これにより、アドバイス側が失敗しても本セクションは正常に表示できる (plan §5.3)。
+ */
+type Props =
+  | {
+      status: "success";
+      items: PendingConsultationDetail[];
+    }
+  | {
+      status: "error";
+      message: string;
+    };
+
+export const PendingConsultationList = (props: Props) => {
+  const count = props.status === "success" ? props.items.length : null;
+
+  return (
+    <section className="space-y-3">
+      <header className="flex items-baseline gap-2">
+        <h2 className="text-lg font-bold text-gray-900">相談</h2>
+        {count !== null && (
+          <span className="text-sm text-gray-500">（{count} 件）</span>
+        )}
+      </header>
+
+      {props.status === "error" && (
+        <div
+          className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+          role="alert"
+        >
+          <p>相談の取得に失敗しました</p>
+          <p className="mt-1 text-xs text-red-500">{props.message}</p>
+        </div>
+      )}
+
+      {props.status === "success" && props.items.length === 0 && (
+        <p className="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-500">
+          チェック待ちの相談はありません
+        </p>
+      )}
+
+      {props.status === "success" && props.items.length > 0 && (
+        <ul className="space-y-3">
+          {props.items.map((item) => (
+            <li key={item.id}>
+              <PendingItemCard
+                id={item.id}
+                title={item.title}
+                body={item.body}
+                authorId={item.author_id}
+                createdAt={item.created_at}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+};

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PendingItemCard } from "./PendingItemCard";
+
+describe("PendingItemCard", () => {
+  const baseProps = {
+    id: 42,
+    body: "本文テキスト",
+    authorId: 7,
+    createdAt: "2026-01-15T10:00:00Z",
+  };
+
+  it("id が #付き で表示される", () => {
+    render(<PendingItemCard {...baseProps} />);
+    expect(screen.getByText("#42")).toBeInTheDocument();
+  });
+
+  it("body が表示される", () => {
+    render(<PendingItemCard {...baseProps} />);
+    expect(screen.getByText("本文テキスト")).toBeInTheDocument();
+  });
+
+  it("title が渡されると h3 として描画される (相談用ユースケース)", () => {
+    render(<PendingItemCard {...baseProps} title="相談タイトル" />);
+    const heading = screen.getByRole("heading", {
+      level: 3,
+      name: "相談タイトル",
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it("title が未指定なら h3 が描画されない (アドバイス用ユースケース)", () => {
+    render(<PendingItemCard {...baseProps} />);
+    expect(screen.queryByRole("heading", { level: 3 })).toBeNull();
+  });
+
+  it("authorId が数値だと「ユーザー#{id}」表示になる", () => {
+    render(<PendingItemCard {...baseProps} authorId={123} />);
+    expect(screen.getByText(/投稿者:\s*ユーザー#123/)).toBeInTheDocument();
+  });
+
+  it("authorId が null だと退会/削除済み表示になる", () => {
+    render(<PendingItemCard {...baseProps} authorId={null} />);
+    expect(
+      screen.getByText(/投稿者:\s*退会済み or 削除済みユーザー/),
+    ).toBeInTheDocument();
+  });
+
+  it("meta slot に渡した要素が描画される", () => {
+    render(
+      <PendingItemCard
+        {...baseProps}
+        meta={<span data-testid="meta-marker">所属相談: #99</span>}
+      />,
+    );
+    expect(screen.getByTestId("meta-marker")).toBeInTheDocument();
+  });
+
+  it("createdAt が ja-JP locale で表示される (年が含まれる)", () => {
+    // toLocaleString('ja-JP') の出力は environment 依存だが、年部分はどの locale でも含まれる
+    render(<PendingItemCard {...baseProps} createdAt="2026-01-15T10:00:00Z" />);
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+});

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.tsx
@@ -1,0 +1,64 @@
+/**
+ * pending な相談 / アドバイスを 1 件表示するカード (Server Component)
+ *
+ * 相談用とアドバイス用で別 component にせず、表示する補助情報 (consultation へのリンク等)
+ * を `meta` slot で受ける形にしている。これは将来 author や tag 情報が API 拡張で
+ * 載ってきた際の差し替えを 1 箇所に閉じるため。
+ *
+ * author は API が author_id (number) しか返さないため、暫定で「ユーザー#{id}」表記。
+ * 将来の API 拡張で author.name が取れるようになったら本 component を差し替える。
+ * 詳細は docs/projects/08 §4.1 を参照。
+ */
+type Props = {
+  /** 投稿の DB ID (相談 or アドバイスの id) */
+  id: number;
+  /** 相談タイトル。アドバイスでは undefined */
+  title?: string;
+  body: string;
+  /** 投稿者の業務 user id。退会済み等で null になり得る */
+  authorId: number | null;
+  /** ISO 8601 created_at */
+  createdAt: string;
+  /** カード末尾に追加表示したい補助情報 (例: 所属相談 id へのリンク) */
+  meta?: React.ReactNode;
+};
+
+const formatAuthor = (authorId: number | null): string => {
+  if (authorId === null) return "退会済み or 削除済みユーザー";
+  // 暫定: author 名取得は API 拡張待ち (docs/projects/08 §4.1)
+  return `ユーザー#${authorId}`;
+};
+
+const formatCreatedAt = (createdAt: string): string => {
+  // タイムゾーンは SSR で UTC になる既知の課題があるが、本 PR では深追いしない
+  return new Date(createdAt).toLocaleString("ja-JP");
+};
+
+export const PendingItemCard = ({
+  id,
+  title,
+  body,
+  authorId,
+  createdAt,
+  meta,
+}: Props) => {
+  return (
+    <article className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-4 text-xs text-gray-500">
+        <span>#{id}</span>
+        <span>{formatCreatedAt(createdAt)}</span>
+      </div>
+
+      {title !== undefined && (
+        <h3 className="mt-2 text-lg font-semibold text-gray-900">{title}</h3>
+      )}
+
+      <p className="mt-2 whitespace-pre-wrap text-sm text-gray-800">{body}</p>
+
+      <div className="mt-3 flex items-center justify-between gap-4 text-xs text-gray-500">
+        <span>投稿者: {formatAuthor(authorId)}</span>
+        {meta}
+      </div>
+    </article>
+  );
+};

--- a/apps/fumufumu-frontend/src/features/admin-content-check/types/index.ts
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/types/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Admin 投稿チェック関連の型定義
+ *
+ * バックエンドの真実は `apps/fumufumu-backend/src/services/consultation-content-check.service.ts`
+ * および `apps/fumufumu-backend/src/db/schema/content-checks.ts` に定義されている。
+ * 本 file は frontend で必要な分のみを mirror する。
+ * source 側の変更時は本 file も追従させること。
+ */
+
+/**
+ * 投稿チェックステータス。本一覧 view では "pending" だけが現れる想定だが、
+ * バックエンドの enum をそのまま受けられるよう全値を残す。
+ */
+export type ContentCheckStatus = "pending" | "approved" | "rejected";
+
+// ============================================
+// 相談 (consultation) の投稿チェック
+// ============================================
+
+/** `?view=summary` のレスポンス要素 */
+export interface PendingConsultationSummary {
+  id: number;
+  status: ContentCheckStatus;
+  created_at: string;
+}
+
+export interface PendingConsultationListResponse {
+  consultations: PendingConsultationSummary[];
+}
+
+/** `?view=detail` のレスポンス要素 */
+export interface PendingConsultationDetail {
+  id: number;
+  title: string;
+  body: string;
+  author_id: number | null;
+  status: ContentCheckStatus;
+  created_at: string;
+}
+
+export interface PendingConsultationDetailResponse {
+  consultations: PendingConsultationDetail[];
+  missing_ids: number[];
+  non_pending: Array<{ id: number; current_status: string }>;
+}
+
+// ============================================
+// アドバイス (advice) の投稿チェック
+// ============================================
+
+/** `?view=summary` のレスポンス要素 */
+export interface PendingAdviceSummary {
+  id: number;
+  consultation_id: number;
+  status: ContentCheckStatus;
+  created_at: string;
+}
+
+export interface PendingAdviceListResponse {
+  advices: PendingAdviceSummary[];
+}
+
+/** `?view=detail` のレスポンス要素 */
+export interface PendingAdviceDetail {
+  id: number;
+  consultation_id: number;
+  body: string;
+  author_id: number | null;
+  status: ContentCheckStatus;
+  created_at: string;
+}
+
+export interface PendingAdviceDetailResponse {
+  advices: PendingAdviceDetail[];
+  missing_ids: number[];
+  non_pending: Array<{ id: number; current_status: string }>;
+}

--- a/docs/projects/08-admin-content-check-list-view.md
+++ b/docs/projects/08-admin-content-check-list-view.md
@@ -181,10 +181,21 @@ src/features/admin-content-check/
 - 空状態 / エラー時 UI もこの Step に含める
 - 動作確認: ローカル dev server で admin ログイン → /admin → 一覧表示
 
-### Step 3 (必要なら): 既存テストへの影響確認・微調整
+### Step 3: 追加 UI component の vitest テスト
 
-- 既存の admin-guard.integration.test.ts は引き続き 200 を期待しているか確認
-- frontend test の追加は本 PR スコープでは行わない（Button 以外に component test 体制が無い）
+当初は「frontend の component test 体制が無い」と認識していたが、実際には vitest + @testing-library/react + @testing-library/jest-dom (vitest entry) + jsdom が `apps/fumufumu-frontend` に既に揃っていた (Button.test.tsx が前例)。
+そのため本 PR で追加した UI component に対するリグレッション防止テストを同梱する。
+
+対象と粒度:
+
+- `PendingItemCard.test.tsx`: title 有/無の分岐、authorId null / 数値の表示、meta slot の有無、created_at の日本語ロケール表示
+- `PendingConsultationList.test.tsx`: success + items / success + empty / error の 3 状態の表示分岐、件数バッジの存在
+- `PendingAdviceList.test.tsx`: 同上 + 所属相談 link が target="_blank" で出ているか
+
+意図的に含めないテスト:
+
+- `page.tsx` (Server Component): `Promise.allSettled` over server-only fetchers の組合せで、`next/headers` の `cookies()` mocking が fragile。E2E (将来の Playwright 等) に寄せるべき領域
+- `adminContentCheckApi.ts` (server-only): 同上の理由。API contract は backend 統合テスト (admin-guard) でカバー済みのため重複を避ける
 
 ---
 

--- a/docs/projects/08-admin-content-check-list-view.md
+++ b/docs/projects/08-admin-content-check-list-view.md
@@ -1,0 +1,232 @@
+# 08. 管理画面 投稿チェック一覧（Admin Content Check List View）
+
+このドキュメントは、ADR 010（管理画面 /admin の権限制御）と ADR 007（投稿チェック機能 MVP 運用）を前提に、`/admin` で投稿チェック対象（pending な相談・アドバイス）の一覧表示を実装するための作業計画である。
+
+ADR 010 §1 で /admin の目的として「投稿チェック機能の一連の管理」を挙げているが、これは複数 PR に分割して進める。本ドキュメントは **第一弾「一覧表示のみ」** のスコープを扱う。
+
+---
+
+## 1. 目的と前提
+
+### 1.1 目的
+
+- 運営者 (`role === 'admin'`) が `/admin` 配下で、**承認待ち（pending）の相談・アドバイスを一覧で確認できる** 状態にする
+- これにより「今承認すべき投稿がどれだけあるか」「投稿内容に問題が無いか目視で確認する」を運営フローに乗せられるようにする
+
+### 1.2 前提（既に整備済み）
+
+- ADR 010: `/admin` への role guard（フロント layout / バック adminGuard）が稼働中
+- ADR 007: 投稿チェックの DB 設計（`content_checks` テーブル）と運用 API（`/api/admin/content-check/*`）が既に存在
+- ADR 009: 承認時のメール送信導線が `ctx.waitUntil()` で実装済み（承認操作自体は本 PR スコープ外）
+- 初期 admin ユーザーが付与済み（DB 直 UPDATE、ADR 010 §3）
+
+### 1.3 本 PR のスコープ（明確に "一覧のみ"）
+
+- pending な相談・アドバイスを admin が一覧で見られる
+- 承認 / 却下の操作 UI、詳細遷移、ページング、編集機能は **本 PR では含めない**
+
+---
+
+## 2. ゴール（Done の定義）
+
+- `/admin` を開くと「投稿チェック」タブ的なエリアが表示される
+- 「相談 (pending)」「アドバイス (pending)」の 2 セクションが見える
+- 各アイテムについて、運営が「承認すべきか」をある程度判断できる情報（タイトル / 本文 / 作成日時 / 投稿者識別子）が表示される
+- pending が 0 件の場合は空状態を明示する
+- 非 admin が叩いた場合は ADR 010 の guard により 404（既存挙動を維持）
+- バックエンドへの変更なし、または極小（後述）
+
+---
+
+## 3. 既存 API の網羅調査
+
+ユーザー要望「既存 API だけでこの画面の作成が可能かを網羅的に確かめる」に応えるため、関連 API を全列挙する。
+
+### 3.1 利用可能なエンドポイント
+
+すべて `authGuard → adminGuard` 適用済み（ADR 010）。
+
+| Method | Path | 用途 | レスポンス概要 |
+|---|---|---|---|
+| GET | `/api/admin/content-check/consultations?view=summary` | pending 相談の **id 一覧** | `{ consultations: [{ id, status, created_at }] }` |
+| GET | `/api/admin/content-check/consultations?view=detail&ids=1,2,3` | 指定 id の **詳細**（title / body / author_id） | `{ consultations: [{ id, title, body, author_id, status, created_at }], missing_ids, non_pending }` |
+| POST | `/api/admin/content-check/consultations/:id/decision` | 相談の承認/却下 | （**本 PR では使わない**） |
+| GET | `/api/admin/content-check/advices?view=summary` | pending アドバイスの **id 一覧** | `{ advices: [{ id, consultation_id, status, created_at }] }` |
+| GET | `/api/admin/content-check/advices?view=detail&ids=1,2,3` | 指定 id の **詳細**（body / author_id / consultation_id） | `{ advices: [{ id, consultation_id, body, author_id, status, created_at }], missing_ids, non_pending }` |
+| POST | `/api/admin/content-check/advices/:id/decision` | アドバイスの承認/却下 | （**本 PR では使わない**） |
+
+### 3.2 利用パターン: 2-call (summary → detail)
+
+「pending の全件を表示する」という本 PR の要件を、既存 API で満たすには次のフローになる：
+
+1. `GET ...?view=summary` で **pending な全 id を取得**（作成順）
+2. `GET ...?view=detail&ids=<summary で取った全 id>` で title / body / author_id を取得
+3. UI に並べる
+
+相談・アドバイスでそれぞれ 2 call、合計 4 call。pending 件数が少ない MVP では妥当。
+
+> 単純な 1-call（summary が title / body まで返す）にしない理由は ADR 007 / 関連 PR で「summary は軽量、detail は明示的に id 指定」と分離する判断がされているため。本 PR ではその判断を踏襲する。
+
+### 3.3 既存 API でカバーできること / できないこと
+
+| 表示したい情報 | 既存 API でカバー | 備考 |
+|---|---|---|
+| pending な相談 / アドバイスの存在自体 | ✅ | summary で取れる |
+| タイトル（相談） | ✅ | detail で取れる |
+| 本文 | ✅ | detail で取れる |
+| 作成日時 | ✅ | summary / detail どちらでも取れる |
+| `author_id`（投稿者の識別子） | ✅ | detail で取れる |
+| **投稿者の表示名（author.name）** | ❌ | API は `author_id` (number) しか返さない |
+| **タグ情報（相談）** | ❌ | content-check API は tags を返さない |
+| `consultation_id`（アドバイス所属の相談） | ✅ | summary / detail どちらでも取れる |
+| **所属相談のタイトル**（アドバイス側） | ❌ | API は `consultation_id` しか返さない |
+| 既に承認済み / 却下済みの履歴 | ❌ | content-check は **pending のみ** を返す（既存仕様） |
+
+---
+
+## 4. ギャップへの対処方針
+
+§3.3 で「❌」となった項目について、本 PR でどう扱うかを決める。
+
+### 4.1 投稿者の表示名 (author.name)
+
+**方針: 暫定で `ユーザー#{author_id}` 表記とし、API 拡張は別 PR に切り出す。**
+
+理由:
+
+- 本 PR は「一覧のみ」のスコープ。author 表示の拡張で diff を増やしたくない
+- author_id だけでも「同じ投稿者が複数 pending を持っている」程度の運用観察はできる
+- 将来的な API 拡張（`view=detail` のレスポンスに `author: { id, name, disabled }` を含める）は、既存の `Author` 型と整合させる形で別 PR で実施する想定
+
+### 4.2 タグ情報（相談）
+
+**方針: 本 PR では表示しない。** 承認判断は title + body で十分行えるため。
+
+将来「タグ別に pending を絞り込みたい」「承認時にタグを編集したい」要望が出たら別 PR で API 拡張する。
+
+### 4.3 所属相談のタイトル（アドバイス側）
+
+**方針: 本 PR では表示しない。** `consultation_id` のみ表示し、必要なら admin が `/consultations/<id>` を別タブで開いて確認する運用とする。
+
+将来 admin の UX 改善で必要になったら、advice detail API に `consultation: { id, title }` を含める拡張を別 PR で。
+
+### 4.4 既に承認済み / 却下済みの履歴
+
+**方針: 本 PR スコープ外。** ADR 007 設計上、content-check 一覧は pending 限定。承認履歴を見たい要件は本機能の MVP に含まれない。
+
+---
+
+## 5. 設計判断
+
+### 5.1 フロントエンドのディレクトリ配置
+
+| 提案 | パス | 妥当性 |
+|---|---|---|
+| 採用 | `apps/fumufumu-frontend/src/features/admin-content-check/` | 「admin 専用機能」と明示でき、将来の admin 系機能（ユーザー管理等）と並列に置ける |
+| 不採用 | `features/content-check/` | 既存の `features/consultation/` と概念が近すぎて混乱する。admin 専用文脈を消してしまう |
+| 不採用 | `features/admin/content-check/` | ネストが深いだけで、現時点では admin 系が 1 機能しか無いので過剰 |
+
+具体的なファイル構成：
+
+```
+src/features/admin-content-check/
+├── api/
+│   └── adminContentCheckApi.ts       # server-only / fetchPendingConsultationsApi / fetchPendingAdvicesApi
+├── components/
+│   ├── PendingConsultationList.tsx   # 相談 pending リスト
+│   ├── PendingAdviceList.tsx         # アドバイス pending リスト
+│   └── PendingItemCard.tsx           # 共通カード（タイトル無し版も流せる形）
+└── types/
+    └── index.ts                       # PendingConsultation, PendingAdvice 等
+```
+
+### 5.2 ページ構成
+
+- `apps/fumufumu-frontend/src/app/(main)/admin/page.tsx` を書き換える
+- 既存の「管理画面（仮）」プレースホルダを撤去
+- Server Component で API を呼び、両リストを並べる
+- CLAUDE.md ルール（`useEffect` 既定禁止）に整合させるため、データ取得は Server Component で完結
+
+### 5.3 API 呼び出しの順序とエラーハンドリング
+
+- `Promise.all([fetchSummaryConsultations(), fetchSummaryAdvices()])` で同時取得
+- それぞれの summary 結果から id を抽出し、ids が 0 件でなければ detail を呼ぶ
+- どちらかが失敗しても画面全体を白くせず、失敗セクションだけエラー表示
+- いずれの API も 4xx / 5xx は ApiError を throw する既存 `apiClient` の挙動に乗る
+
+### 5.4 表示しないことの明示
+
+「タグが表示されていない」「投稿者名が author_id 表記」等は **UI 側に注意書きを置かない**。本 PR はスコープを絞った MVP であり、ノイズになる注釈を入れない方が運営者に混乱が少ない。代わりに本ドキュメントと PR description に明記する。
+
+---
+
+## 6. 実装ステップ（コミット境界）
+
+スモールステップで進めるため、以下の単位でコミットを分ける。各ステップ完了時にレビューを受ける。
+
+### Step 1: 型定義 + API client（server-only）
+
+- `features/admin-content-check/types/index.ts` を作成
+  - `PendingConsultationSummary` / `PendingConsultationDetail` 等
+- `features/admin-content-check/api/adminContentCheckApi.ts` を作成
+  - `fetchPendingConsultationsApi()`: summary → detail の 2-call を内包
+  - `fetchPendingAdvicesApi()`: 同上
+- バックエンド変更なし
+- 動作確認: 単独では UI が無いため、次ステップで併せて確認
+
+### Step 2: 一覧 UI コンポーネント + page.tsx 書き換え
+
+- `PendingConsultationList`, `PendingAdviceList`, `PendingItemCard` を実装
+- `(main)/admin/page.tsx` を書き換え、Server Component で 2 つの fetch を実行し UI に流す
+- 空状態 / エラー時 UI もこの Step に含める
+- 動作確認: ローカル dev server で admin ログイン → /admin → 一覧表示
+
+### Step 3 (必要なら): 既存テストへの影響確認・微調整
+
+- 既存の admin-guard.integration.test.ts は引き続き 200 を期待しているか確認
+- frontend test の追加は本 PR スコープでは行わない（Button 以外に component test 体制が無い）
+
+---
+
+## 7. このPRで意図的に含めないこと
+
+- 承認 / 却下の操作 UI（次の PR）
+- 投稿チェック詳細ページへの遷移
+- ページング（pending 件数が増えてきたら別 PR で導入）
+- 投稿者の表示名取得（API 拡張を別 PR で）
+- タグ情報の表示（同上）
+- アドバイス側で所属相談タイトルを併記する（同上）
+- 承認済み / 却下済みの履歴閲覧（MVP スコープ外）
+- ヘッダーへの「管理画面」ナビゲーション追加（admin 自身は URL 直打ちで来る前提、UI 露出は ADR 010 §5 の方針に従って単独 PR で扱う）
+
+---
+
+## 8. 後続作業（次以降の PR 想定）
+
+1. **承認 / 却下 UI** — `POST /api/admin/content-check/.../decision` を叩く form + 楽観的更新
+2. **author 情報の API 拡張** — `view=detail` レスポンスに `author: { id, name, disabled }` を含める
+3. **アドバイス側で所属相談タイトル併記** — advice detail API 拡張
+4. **承認済み / 却下済みの履歴閲覧** — content-check API に history view 追加
+5. **ページング** — pending 件数が運用に響く規模になってから
+
+---
+
+## 9. 確認したい点（実装着手前に user に確認）
+
+以下の判断は本ドキュメントで暫定方針を置いているが、user 判断が必要：
+
+1. **feature dir 名**: `features/admin-content-check/` で良いか？
+2. **author 表示**: `ユーザー#{author_id}` 暫定で良いか？ それとも本 PR 内で API 拡張までやりたいか？
+3. **タグ・所属相談タイトル**: 本 PR では出さない方針で良いか？
+4. **承認待ち件数の数字表示**: 「相談 pending: 3 件」のような件数バッジを section header に出すか？（UI 実装コストは小、データは summary レスポンスから無料で取れる）
+5. **タブ分けするか並列で表示するか**: 相談セクションとアドバイスセクションを **同一ページに縦並び** で出す案を採用しているが、Tab で切り替える形にしたい？
+
+---
+
+## 10. 関連
+
+- ADR 007: [`docs/design/adr/007-content-check-mvp-operation-strategy.md`](../design/adr/007-content-check-mvp-operation-strategy.md) — content-check の DB 設計と運用方針
+- ADR 009: [`docs/design/adr/009-email-notification-delivery-strategy-mvp.md`](../design/adr/009-email-notification-delivery-strategy-mvp.md) — 承認時メール送信
+- ADR 010: [`docs/design/adr/010-admin-permissions-mvp.md`](../design/adr/010-admin-permissions-mvp.md) — /admin の権限制御
+- 既存 API: [`apps/fumufumu-backend/src/routes/admin-content-check.controller.ts`](../../apps/fumufumu-backend/src/routes/admin-content-check.controller.ts)
+- 既存 Service: [`apps/fumufumu-backend/src/services/consultation-content-check.service.ts`](../../apps/fumufumu-backend/src/services/consultation-content-check.service.ts)


### PR DESCRIPTION
## 背景

ADR 010「管理画面 /admin の権限制御 MVP 方針」§1 で /admin の用途として「投稿チェック機能の一連の管理」を挙げているが、前 PR (feature/admin-guard) では role guard までしか実装しておらず、画面の中身は「管理画面（仮）」プレースホルダのままだった。

ADR 007 で投稿チェックの DB 設計と運用 API (`/api/admin/content-check/*`) は既に整備されており、ADR 009 のメール送信導線も実装済み。残るは「運営者が承認待ち投稿を見られる UI」で、本 PR はその第一弾。

## このPRで解決すること

`/admin` で **pending な相談・アドバイスの一覧** を表示する。既存の `/api/admin/content-check/*` を消費するだけで **バックエンドは一切変更しない**。承認 / 却下の操作 UI は次の PR で扱い、本 PR は「表示のみ」にスコープを絞る。

実装前に [docs/projects/08-admin-content-check-list-view.md](docs/projects/08-admin-content-check-list-view.md) を起こし、既存 API で要件を満たせるかの網羅調査・設計判断（レイアウト案 / 2-call パターン / per-section エラーハンドリング等）を固定してから着手している。詳細は同 doc。

## 含まれる変更（10 ファイル）

| 種別 | ファイル | 内容 |
|---|---|---|
| docs | `docs/projects/08-admin-content-check-list-view.md` | 実装計画書 |
| feature/types | `features/admin-content-check/types/index.ts` | backend レスポンスの mirror 型 |
| feature/api | `features/admin-content-check/api/adminContentCheckApi.ts` | summary → detail の 2-call を内包する server-only fetcher |
| feature/components | `PendingItemCard.tsx` | 1 件分の card。title 有/無の共通化、meta slot で将来拡張に備える |
| feature/components | `PendingConsultationList.tsx` / `PendingAdviceList.tsx` | 各セクション。success / error / empty の 3 状態 + 件数バッジ |
| feature/components | `*.test.tsx` (×3) | 各 component の vitest テスト 計 15 ケース |
| page | `app/(main)/admin/page.tsx` | プレースホルダから Server Component に書き換え、2 セクションを並列描画 |

すべて Server Component（CLAUDE.md ルール: `useEffect` 既定禁止）。

## 既存 API でカバーできないこと（本 PR では暫定対応）

| 不足情報 | 本 PR での扱い | 追跡 |
|---|---|---|
| 投稿者の表示名 (`author.name`) | 暫定で「ユーザー#{author_id}」表記 | #143 |
| タグ情報（相談） | 表示しない | #143 |
| 所属相談タイトル（アドバイス） | `consultation_id` への新タブ link のみ表示 | #143 |
| 承認済み / 却下済み投稿の履歴 | スコープ外（ADR 007 設計上 pending 限定） | — |

セルフレビュー時に派生した話題（snake_case / camelCase の API 命名揺れ、SSR の UTC timezone）は別 Issue 化済み。

## このPRで意図的に含めないこと

- 承認 / 却下の操作 UI（次の PR）
- ページング（pending 件数が増えてきたら別 PR）
- ヘッダーへの「管理画面」ナビゲーション追加（ADR 010 §5 方針として URL 直打ち前提）
- `page.tsx` / `adminContentCheckApi.ts` の自動テスト
  - Server Component / server-only の mocking が fragile な領域
  - API contract は backend 統合テスト (admin-guard.integration.test.ts) でカバー済み

## 動作確認

- frontend: 17 tests pass（既存 Button 2 + 新規 15）、biome clean、tsc は既存 worker.ts 警告のみ
- backend: 168 tests pass（本 PR では backend 無変更、念のため）
- 実機 (ローカル): admin で `/admin` → 2 セクション描画、非 admin で `/admin` → 404 維持

## レビュー時に見てほしい点

- `PendingItemCard` の `meta` slot 設計が将来の API 拡張時に差し替えやすい形か
- `page.tsx` の `Promise.allSettled` per-section エラーハンドリングが過不足ないか
- `toListProps` helper の generic 抽象化レベルが「2 component で共有」の現状規模に対して適切か

## 関連

- ADR 007 / 009 / 010
- 計画書: [`docs/projects/08-admin-content-check-list-view.md`](docs/projects/08-admin-content-check-list-view.md)
- 直前 PR: feature/admin-guard（/admin の role guard、merged）
- 派生 Issue: #143（admin detail API 拡張）/ snake_case 命名揺れ / SSR timezone（番号は user 起票分を反映）
- 後続 PR: 承認 / 却下の操作 UI