### PR TITLE
✨feat(admin-content-check): /admin で pending な投稿を承認 / 却下できるようにする

### DIFF
--- a/apps/fumufumu-frontend/src/features/admin-content-check/api/adminContentCheckDecisionApi.ts
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/api/adminContentCheckDecisionApi.ts
@@ -1,0 +1,45 @@
+import { apiClient } from "@/lib/api/client";
+
+type DecideConsultationContentCheckResponse = {
+  consultation_id: number;
+  status: "approved" | "rejected";
+  reason: string | null;
+  checked_at: string | null;
+  updated_at: string;
+};
+
+type DecideAdviceContentCheckResponse = {
+  advice_id: number;
+  status: "approved" | "rejected";
+  reason: string | null;
+  checked_at: string | null;
+  updated_at: string;
+};
+
+export const decideConsultationApi = (
+  consultationId: number,
+  decision: "approved" | "rejected",
+  reason?: string,
+) => {
+  return apiClient<DecideConsultationContentCheckResponse>(
+    `/api/admin/content-check/consultations/${consultationId}/decision`,
+    {
+      method: "POST",
+      body: JSON.stringify({ decision, reason }),
+    },
+  );
+};
+
+export const decideAdviceApi = (
+  adviceId: number,
+  decision: "approved" | "rejected",
+  reason?: string,
+) => {
+  return apiClient<DecideAdviceContentCheckResponse>(
+    `/api/admin/content-check/advices/${adviceId}/decision`,
+    {
+      method: "POST",
+      body: JSON.stringify({ decision, reason }),
+    },
+  );
+};

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import toast from "react-hot-toast";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "@/lib/api/client";
+import {
+  decideAdviceApi,
+  decideConsultationApi,
+} from "../api/adminContentCheckDecisionApi";
+import { DecisionActions } from "./DecisionActions";
+
+vi.mock("../api/adminContentCheckDecisionApi", () => ({
+  decideConsultationApi: vi.fn(),
+  decideAdviceApi: vi.fn(),
+}));
+
+vi.mock("react-hot-toast", () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// 却下フローは RejectDialog.test.tsx で詳細検証する。本ファイルでは
+// DecisionActions が onSubmit に reason を渡す配線だけ確認できれば十分なので、
+// stub で「クリック1回 = onSubmit('test reason') 呼び出し」に縮約する。
+vi.mock("./RejectDialog", () => ({
+  RejectDialog: ({
+    onSubmit,
+    isSubmitting,
+  }: {
+    onSubmit: (reason: string) => Promise<void>;
+    isSubmitting: boolean;
+  }) => (
+    <button
+      type="button"
+      data-testid="reject-stub"
+      disabled={isSubmitting}
+      onClick={() => onSubmit("test reason")}
+    >
+      却下
+    </button>
+  ),
+}));
+
+const dummyConsultationResponse = {
+  consultation_id: 1,
+  status: "approved" as const,
+  reason: null,
+  checked_at: "2026-06-28T00:00:00Z",
+  updated_at: "2026-06-28T00:00:00Z",
+};
+const dummyAdviceResponse = {
+  advice_id: 1,
+  status: "approved" as const,
+  reason: null,
+  checked_at: "2026-06-28T00:00:00Z",
+  updated_at: "2026-06-28T00:00:00Z",
+};
+
+describe("DecisionActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("承認パス", () => {
+    it("confirm OK で kind=consultation の場合 decideConsultationApi が approved で呼ばれる", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, "confirm").mockReturnValue(true);
+      vi.mocked(decideConsultationApi).mockResolvedValue(
+        dummyConsultationResponse,
+      );
+
+      render(<DecisionActions kind="consultation" itemId={42} />);
+      await user.click(screen.getByRole("button", { name: "承認" }));
+
+      expect(decideConsultationApi).toHaveBeenCalledWith(
+        42,
+        "approved",
+        undefined,
+      );
+      expect(decideAdviceApi).not.toHaveBeenCalled();
+    });
+
+    it("kind=advice なら decideAdviceApi が呼ばれる", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, "confirm").mockReturnValue(true);
+      vi.mocked(decideAdviceApi).mockResolvedValue(dummyAdviceResponse);
+
+      render(<DecisionActions kind="advice" itemId={7} />);
+      await user.click(screen.getByRole("button", { name: "承認" }));
+
+      expect(decideAdviceApi).toHaveBeenCalledWith(7, "approved", undefined);
+      expect(decideConsultationApi).not.toHaveBeenCalled();
+    });
+
+    it("confirm Cancel なら API が呼ばれない", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, "confirm").mockReturnValue(false);
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByRole("button", { name: "承認" }));
+
+      expect(decideConsultationApi).not.toHaveBeenCalled();
+    });
+
+    it("成功時に toast.success('承認しました') が呼ばれる", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, "confirm").mockReturnValue(true);
+      vi.mocked(decideConsultationApi).mockResolvedValue(
+        dummyConsultationResponse,
+      );
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByRole("button", { name: "承認" }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("承認しました");
+      });
+    });
+
+    it("ApiError(404) で「他の管理者が...」toast が出る", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, "confirm").mockReturnValue(true);
+      vi.mocked(decideConsultationApi).mockRejectedValue(
+        new ApiError(404, "Not Found"),
+      );
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByRole("button", { name: "承認" }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "他の管理者が既に処理した可能性があります",
+        );
+      });
+    });
+
+    it("ApiError(500) で「承認に失敗しました」toast が出る", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, "confirm").mockReturnValue(true);
+      vi.mocked(decideConsultationApi).mockRejectedValue(
+        new ApiError(500, "Internal Error"),
+      );
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByRole("button", { name: "承認" }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("承認に失敗しました");
+      });
+    });
+  });
+
+  describe("却下パス", () => {
+    it("却下フローで decideConsultationApi が rejected と reason で呼ばれる", async () => {
+      const user = userEvent.setup();
+      vi.mocked(decideConsultationApi).mockResolvedValue({
+        ...dummyConsultationResponse,
+        status: "rejected",
+        reason: "test reason",
+      });
+
+      render(<DecisionActions kind="consultation" itemId={42} />);
+      await user.click(screen.getByTestId("reject-stub"));
+
+      await waitFor(() => {
+        expect(decideConsultationApi).toHaveBeenCalledWith(
+          42,
+          "rejected",
+          "test reason",
+        );
+      });
+      expect(toast.success).toHaveBeenCalledWith("却下しました");
+    });
+
+    it("kind=advice なら decideAdviceApi が rejected で呼ばれる", async () => {
+      const user = userEvent.setup();
+      vi.mocked(decideAdviceApi).mockResolvedValue({
+        ...dummyAdviceResponse,
+        status: "rejected",
+        reason: "test reason",
+      });
+
+      render(<DecisionActions kind="advice" itemId={7} />);
+      await user.click(screen.getByTestId("reject-stub"));
+
+      await waitFor(() => {
+        expect(decideAdviceApi).toHaveBeenCalledWith(
+          7,
+          "rejected",
+          "test reason",
+        );
+      });
+    });
+
+    it("却下時の ApiError(404) で「他の管理者が...」toast が出る", async () => {
+      const user = userEvent.setup();
+      vi.mocked(decideConsultationApi).mockRejectedValue(
+        new ApiError(404, "Not Found"),
+      );
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByTestId("reject-stub"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "他の管理者が既に処理した可能性があります",
+        );
+      });
+    });
+
+    it("却下時の汎用エラーで「却下に失敗しました」toast が出る", async () => {
+      const user = userEvent.setup();
+      vi.mocked(decideConsultationApi).mockRejectedValue(
+        new ApiError(500, "Internal Error"),
+      );
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByTestId("reject-stub"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("却下に失敗しました");
+      });
+    });
+  });
+});

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.test.tsx
@@ -154,6 +154,24 @@ describe("DecisionActions", () => {
         expect(toast.error).toHaveBeenCalledWith("承認に失敗しました");
       });
     });
+
+    it("非 ApiError (network failure) で「ネットワーク接続を確認してください」toast が出る", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(window, "confirm").mockReturnValue(true);
+      // fetch が TypeError で throw するケースを模す (network down 等)
+      vi.mocked(decideConsultationApi).mockRejectedValue(
+        new TypeError("Failed to fetch"),
+      );
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByRole("button", { name: "承認" }));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "ネットワーク接続を確認してください",
+        );
+      });
+    });
   });
 
   describe("却下パス", () => {
@@ -225,6 +243,22 @@ describe("DecisionActions", () => {
 
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith("却下に失敗しました");
+      });
+    });
+
+    it("却下時の非 ApiError (network failure) で「ネットワーク接続を確認してください」toast が出る", async () => {
+      const user = userEvent.setup();
+      vi.mocked(decideConsultationApi).mockRejectedValue(
+        new TypeError("Failed to fetch"),
+      );
+
+      render(<DecisionActions kind="consultation" itemId={1} />);
+      await user.click(screen.getByTestId("reject-stub"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "ネットワーク接続を確認してください",
+        );
       });
     });
   });

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.tsx
@@ -22,10 +22,20 @@ export const DecisionActions = ({ kind, itemId }: Props) => {
   const decide = async (decision: "approved" | "rejected", reason?: string) => {
     setIsSubmitting(true);
     try {
-      if (kind === "consultation") {
-        await decideConsultationApi(itemId, decision, reason);
-      } else {
-        await decideAdviceApi(itemId, decision, reason);
+      switch (kind) {
+        case "consultation":
+          await decideConsultationApi(itemId, decision, reason);
+          break;
+        case "advice":
+          await decideAdviceApi(itemId, decision, reason);
+          break;
+        default: {
+          // exhaustive check: 将来 kind に値を追加した際に compile error で気付ける。
+          // ここに来る = TS が網羅性チェックを失った状態なので、ランタイムでも明示的に
+          // 落とす。
+          const _exhaustiveCheck: never = kind;
+          throw new Error(`Unknown kind: ${_exhaustiveCheck}`);
+        }
       }
       toast.success(decision === "approved" ? "承認しました" : "却下しました");
       router.refresh();
@@ -35,10 +45,15 @@ export const DecisionActions = ({ kind, itemId }: Props) => {
       if (error instanceof ApiError && error.status === 404) {
         toast.error("他の管理者が既に処理した可能性があります");
         router.refresh();
-      } else {
+      } else if (error instanceof ApiError) {
+        // 4xx / 5xx 等の backend が返した API エラー
         toast.error(
           decision === "approved" ? "承認に失敗しました" : "却下に失敗しました",
         );
+      } else {
+        // ApiError 以外 = fetch 自体が失敗 (network down / CORS / TypeError 等)。
+        // backend に到達できていないので、ユーザにはネットワーク観点の手当を促す
+        toast.error("ネットワーク接続を確認してください");
       }
     } finally {
       setIsSubmitting(false);

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import toast from "react-hot-toast";
+import { ApiError } from "@/lib/api/client";
+import {
+  decideAdviceApi,
+  decideConsultationApi,
+} from "../api/adminContentCheckDecisionApi";
+
+type Props = {
+  kind: "consultation" | "advice";
+  itemId: number;
+};
+
+export const DecisionActions = ({ kind, itemId }: Props) => {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleApprove = async () => {
+    if (!window.confirm("この投稿を承認しますか？")) return;
+
+    setIsSubmitting(true);
+    try {
+      if (kind === "consultation") {
+        await decideConsultationApi(itemId, "approved");
+      } else {
+        await decideAdviceApi(itemId, "approved");
+      }
+      toast.success("承認しました");
+      router.refresh();
+    } catch (error) {
+      // 404: 他 admin が直前に承認/却下済みで pending 行が無い (backend NotFoundError)。
+      // この場合はリストを refresh して該当アイテムを消す方が現実と整合する。
+      if (error instanceof ApiError && error.status === 404) {
+        toast.error("他の管理者が既に処理した可能性があります");
+        router.refresh();
+      } else {
+        toast.error("承認に失敗しました");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleApprove}
+      disabled={isSubmitting}
+      className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      承認
+    </button>
+  );
+};

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/DecisionActions.tsx
@@ -8,6 +8,7 @@ import {
   decideAdviceApi,
   decideConsultationApi,
 } from "../api/adminContentCheckDecisionApi";
+import { RejectDialog } from "./RejectDialog";
 
 type Props = {
   kind: "consultation" | "advice";
@@ -18,17 +19,15 @@ export const DecisionActions = ({ kind, itemId }: Props) => {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleApprove = async () => {
-    if (!window.confirm("この投稿を承認しますか？")) return;
-
+  const decide = async (decision: "approved" | "rejected", reason?: string) => {
     setIsSubmitting(true);
     try {
       if (kind === "consultation") {
-        await decideConsultationApi(itemId, "approved");
+        await decideConsultationApi(itemId, decision, reason);
       } else {
-        await decideAdviceApi(itemId, "approved");
+        await decideAdviceApi(itemId, decision, reason);
       }
-      toast.success("承認しました");
+      toast.success(decision === "approved" ? "承認しました" : "却下しました");
       router.refresh();
     } catch (error) {
       // 404: 他 admin が直前に承認/却下済みで pending 行が無い (backend NotFoundError)。
@@ -37,21 +36,35 @@ export const DecisionActions = ({ kind, itemId }: Props) => {
         toast.error("他の管理者が既に処理した可能性があります");
         router.refresh();
       } else {
-        toast.error("承認に失敗しました");
+        toast.error(
+          decision === "approved" ? "承認に失敗しました" : "却下に失敗しました",
+        );
       }
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  const handleApprove = async () => {
+    if (!window.confirm("この投稿を承認しますか？")) return;
+    await decide("approved");
+  };
+
+  const handleReject = async (reason: string) => {
+    await decide("rejected", reason);
+  };
+
   return (
-    <button
-      type="button"
-      onClick={handleApprove}
-      disabled={isSubmitting}
-      className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed"
-    >
-      承認
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={handleApprove}
+        disabled={isSubmitting}
+        className="rounded-md bg-emerald-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        承認
+      </button>
+      <RejectDialog onSubmit={handleReject} isSubmitting={isSubmitting} />
+    </>
   );
 };

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingAdviceList.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingAdviceList.tsx
@@ -1,4 +1,5 @@
 import type { PendingAdviceDetail } from "../types";
+import { DecisionActions } from "./DecisionActions";
 import { PendingItemCard } from "./PendingItemCard";
 
 /**
@@ -67,6 +68,7 @@ export const PendingAdviceList = (props: Props) => {
                     </a>
                   </span>
                 }
+                actions={<DecisionActions kind="advice" itemId={item.id} />}
               />
             </li>
           ))}

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingConsultationList.tsx
@@ -1,4 +1,5 @@
 import type { PendingConsultationDetail } from "../types";
+import { DecisionActions } from "./DecisionActions";
 import { PendingItemCard } from "./PendingItemCard";
 
 /**
@@ -55,6 +56,9 @@ export const PendingConsultationList = (props: Props) => {
                 body={item.body}
                 authorId={item.author_id}
                 createdAt={item.created_at}
+                actions={
+                  <DecisionActions kind="consultation" itemId={item.id} />
+                }
               />
             </li>
           ))}

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.test.tsx
@@ -56,6 +56,20 @@ describe("PendingItemCard", () => {
     expect(screen.getByTestId("meta-marker")).toBeInTheDocument();
   });
 
+  it("actions slot に渡した要素が描画される", () => {
+    render(
+      <PendingItemCard
+        {...baseProps}
+        actions={
+          <button type="button" data-testid="action-marker">
+            承認
+          </button>
+        }
+      />,
+    );
+    expect(screen.getByTestId("action-marker")).toBeInTheDocument();
+  });
+
   it("createdAt が ja-JP locale で表示される (年が含まれる)", () => {
     // toLocaleString('ja-JP') の出力は environment 依存だが、年部分はどの locale でも含まれる
     render(<PendingItemCard {...baseProps} createdAt="2026-01-15T10:00:00Z" />);

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/PendingItemCard.tsx
@@ -21,6 +21,8 @@ type Props = {
   createdAt: string;
   /** カード末尾に追加表示したい補助情報 (例: 所属相談 id へのリンク) */
   meta?: React.ReactNode;
+  /** カード下端に表示する操作 UI (例: 承認/却下ボタン)。Client Component を渡す想定 */
+  actions?: React.ReactNode;
 };
 
 const formatAuthor = (authorId: number | null): string => {
@@ -41,6 +43,7 @@ export const PendingItemCard = ({
   authorId,
   createdAt,
   meta,
+  actions,
 }: Props) => {
   return (
     <article className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
@@ -59,6 +62,8 @@ export const PendingItemCard = ({
         <span>投稿者: {formatAuthor(authorId)}</span>
         {meta}
       </div>
+
+      {actions && <div className="mt-3 flex justify-end gap-2">{actions}</div>}
     </article>
   );
 };

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.test.tsx
@@ -75,11 +75,11 @@ describe("RejectDialog", () => {
     });
   });
 
-  it("キャンセルボタンで close が呼ばれる", async () => {
+  it("閉じるボタンで close が呼ばれる", async () => {
     const user = userEvent.setup();
     render(<RejectDialog onSubmit={vi.fn()} isSubmitting={false} />);
     await user.click(screen.getByRole("button", { name: "却下" }));
-    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+    await user.click(screen.getByRole("button", { name: "閉じる" }));
     expect(closeSpy).toHaveBeenCalledOnce();
   });
 

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.test.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RejectDialog } from "./RejectDialog";
+
+describe("RejectDialog", () => {
+  let showModalSpy: ReturnType<typeof vi.spyOn>;
+  let closeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // vitest.setup.ts でグローバルに当てた最小スタブの上に spy を被せて
+    // 呼び出し回数を観測する。call-through を維持して open / close も動かす。
+    showModalSpy = vi.spyOn(HTMLDialogElement.prototype, "showModal");
+    closeSpy = vi.spyOn(HTMLDialogElement.prototype, "close");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("却下ボタンクリックで showModal が呼ばれる", async () => {
+    const user = userEvent.setup();
+    render(<RejectDialog onSubmit={vi.fn()} isSubmitting={false} />);
+    await user.click(screen.getByRole("button", { name: "却下" }));
+    expect(showModalSpy).toHaveBeenCalledOnce();
+  });
+
+  it("空のまま送信すると validation error が出て onSubmit は呼ばれない", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<RejectDialog onSubmit={onSubmit} isSubmitting={false} />);
+    await user.click(screen.getByRole("button", { name: "却下" }));
+    await user.click(screen.getByRole("button", { name: "却下する" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "却下理由を入力してください",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("空白のみの reason も validation error 扱いになる (trim 後判定)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<RejectDialog onSubmit={onSubmit} isSubmitting={false} />);
+    await user.click(screen.getByRole("button", { name: "却下" }));
+    await user.type(screen.getByLabelText(/却下理由/), "   ");
+    await user.click(screen.getByRole("button", { name: "却下する" }));
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "却下理由を入力してください",
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("有効な reason で送信すると onSubmit(trimmed) と close が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<RejectDialog onSubmit={onSubmit} isSubmitting={false} />);
+    await user.click(screen.getByRole("button", { name: "却下" }));
+    await user.type(screen.getByLabelText(/却下理由/), "  spam です  ");
+    await user.click(screen.getByRole("button", { name: "却下する" }));
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith("spam です");
+    });
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it("onSubmit が reject しても close は呼ばれる (finally 経由)", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockRejectedValue(new Error("api error"));
+    render(<RejectDialog onSubmit={onSubmit} isSubmitting={false} />);
+    await user.click(screen.getByRole("button", { name: "却下" }));
+    await user.type(screen.getByLabelText(/却下理由/), "reason");
+    await user.click(screen.getByRole("button", { name: "却下する" }));
+    await waitFor(() => {
+      expect(closeSpy).toHaveBeenCalled();
+    });
+  });
+
+  it("キャンセルボタンで close が呼ばれる", async () => {
+    const user = userEvent.setup();
+    render(<RejectDialog onSubmit={vi.fn()} isSubmitting={false} />);
+    await user.click(screen.getByRole("button", { name: "却下" }));
+    await user.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(closeSpy).toHaveBeenCalledOnce();
+  });
+
+  it("isSubmitting=true なら 却下 トリガーが disabled", () => {
+    render(<RejectDialog onSubmit={vi.fn()} isSubmitting={true} />);
+    expect(screen.getByRole("button", { name: "却下" })).toBeDisabled();
+  });
+});

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -5,7 +5,13 @@ import { useId, useRef, useState } from "react";
 const MAX_REASON_LENGTH = 500;
 
 type Props = {
-  /** 却下を確定したとき呼ばれる。throw しても dialog は閉じる (finally で close) */
+  /**
+   * 却下を確定したとき呼ばれる。
+   * 成否にかかわらず dialog は閉じる (finally で close)。
+   * throw された error は内部で握りつぶされるため、user-visible な error
+   * feedback (toast 等) は親 component の責務。何も通知しないと silent fail
+   * になる点に注意。
+   */
   onSubmit: (reason: string) => Promise<void>;
   /** 親 (DecisionActions) の submission 状態と同期。submit ボタンの二重押下防止に使う */
   isSubmitting: boolean;

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -42,8 +42,13 @@ export const RejectDialog = ({ onSubmit, isSubmitting }: Props) => {
 
     // 成功 / 失敗どちらでも dialog は閉じる
     // (成功: list refresh で行が消える / 失敗: toast を親側で出すので dialog は不要)
+    // 親 (DecisionActions.decide) が全エラーを握りつぶす契約だが、safety net で
+    // 本コンポーネント側でも catch する。catch しないと <form onSubmit> から
+    // unhandled rejection として leak する。
     try {
       await onSubmit(trimmed);
+    } catch {
+      // intentionally swallowed; parent is responsible for user-visible error feedback
     } finally {
       handleClose();
     }

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -64,7 +64,7 @@ export const RejectDialog = ({ onSubmit, isSubmitting }: Props) => {
 
       <dialog
         ref={dialogRef}
-        className="w-full max-w-md rounded-lg p-0 shadow-xl backdrop:bg-black/50"
+        className="m-auto w-full max-w-md rounded-lg p-0 shadow-xl backdrop:bg-black/50"
       >
         <form onSubmit={handleSubmit} className="space-y-4 p-6">
           <h2 className="text-lg font-bold text-gray-900">投稿を却下する</h2>

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -2,6 +2,11 @@
 
 import { useId, useRef, useState } from "react";
 
+// backend validator (apps/fumufumu-backend/src/validators/content-check.validator.ts)
+// の reason 上限 (.max(500)) と同条件で宣言している。frontend 側のクライアント
+// バリデーションでカバーしたいだけで、本来は同じ schema / 定数を frontend から
+// 共有して参照すべき。片方を変えるともう片方も同時に更新する必要がある。
+// 共有定数化の検討は別 issue に切り出して扱う。
 const MAX_REASON_LENGTH = 500;
 
 type Props = {

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -119,7 +119,7 @@ export const RejectDialog = ({ onSubmit, isSubmitting }: Props) => {
               onClick={handleClose}
               className="rounded-md border border-gray-300 px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
             >
-              キャンセル
+              閉じる
             </button>
             <button
               type="submit"

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 
 const MAX_REASON_LENGTH = 500;
 
@@ -13,6 +13,13 @@ type Props = {
 
 export const RejectDialog = ({ onSubmit, isSubmitting }: Props) => {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  // 親 (DecisionActions) は pending item の数だけ RejectDialog をレンダーする。
+  // id をベタ書きにすると document 内で衝突し、label↔textarea のペアリングや
+  // aria-labelledby の参照が「最初に見つかった一致」に倒れて壊れる。
+  // SSR/CSR で安定 (hydration mismatch を起こさない) かつ instance ごとに
+  // 一意になる id を React の useId で生成する。
+  const titleId = useId();
+  const reasonId = useId();
   const [reason, setReason] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -69,19 +76,22 @@ export const RejectDialog = ({ onSubmit, isSubmitting }: Props) => {
 
       <dialog
         ref={dialogRef}
+        aria-labelledby={titleId}
         className="m-auto w-full max-w-md rounded-lg p-0 shadow-xl backdrop:bg-black/50"
       >
         <form onSubmit={handleSubmit} className="space-y-4 p-6">
-          <h2 className="text-lg font-bold text-gray-900">投稿を却下する</h2>
+          <h2 id={titleId} className="text-lg font-bold text-gray-900">
+            投稿を却下する
+          </h2>
           <div>
             <label
-              htmlFor="reject-reason"
+              htmlFor={reasonId}
               className="block text-sm font-medium text-gray-700"
             >
               却下理由（1〜{MAX_REASON_LENGTH} 文字）
             </label>
             <textarea
-              id="reject-reason"
+              id={reasonId}
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               rows={5}

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+const MAX_REASON_LENGTH = 500;
+
+type Props = {
+  /** 却下を確定したとき呼ばれる。throw しても dialog は閉じる (finally で close) */
+  onSubmit: (reason: string) => Promise<void>;
+  /** 親 (DecisionActions) の submission 状態と同期。submit ボタンの二重押下防止に使う */
+  isSubmitting: boolean;
+};
+
+export const RejectDialog = ({ onSubmit, isSubmitting }: Props) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [reason, setReason] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleOpen = () => {
+    setReason("");
+    setError(null);
+    dialogRef.current?.showModal();
+  };
+
+  const handleClose = () => {
+    dialogRef.current?.close();
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = reason.trim();
+
+    if (trimmed.length === 0) {
+      setError("却下理由を入力してください");
+      return;
+    }
+    if (trimmed.length > MAX_REASON_LENGTH) {
+      setError(`理由は${MAX_REASON_LENGTH}文字以内で入力してください`);
+      return;
+    }
+    setError(null);
+
+    // 成功 / 失敗どちらでも dialog は閉じる
+    // (成功: list refresh で行が消える / 失敗: toast を親側で出すので dialog は不要)
+    try {
+      await onSubmit(trimmed);
+    } finally {
+      handleClose();
+    }
+  };
+
+  const remaining = MAX_REASON_LENGTH - reason.length;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={isSubmitting}
+        className="rounded-md border border-red-300 px-4 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        却下
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        className="w-full max-w-md rounded-lg p-0 shadow-xl backdrop:bg-black/50"
+      >
+        <form onSubmit={handleSubmit} className="space-y-4 p-6">
+          <h2 className="text-lg font-bold text-gray-900">投稿を却下する</h2>
+          <div>
+            <label
+              htmlFor="reject-reason"
+              className="block text-sm font-medium text-gray-700"
+            >
+              却下理由（1〜{MAX_REASON_LENGTH} 文字）
+            </label>
+            <textarea
+              id="reject-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={5}
+              maxLength={MAX_REASON_LENGTH}
+              disabled={isSubmitting}
+              className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-teal-500 focus:outline-none focus:ring-1 focus:ring-teal-500 disabled:bg-gray-100"
+            />
+            <p className="mt-1 text-xs text-gray-500">残り {remaining} 文字</p>
+          </div>
+          {error && (
+            <p role="alert" className="text-sm text-red-600">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="rounded-md border border-gray-300 px-4 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-red-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              却下する
+            </button>
+          </div>
+        </form>
+      </dialog>
+    </>
+  );
+};

--- a/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
+++ b/apps/fumufumu-frontend/src/features/admin-content-check/components/RejectDialog.tsx
@@ -52,10 +52,6 @@ export const RejectDialog = ({ onSubmit, isSubmitting }: Props) => {
       setError("却下理由を入力してください");
       return;
     }
-    if (trimmed.length > MAX_REASON_LENGTH) {
-      setError(`理由は${MAX_REASON_LENGTH}文字以内で入力してください`);
-      return;
-    }
     setError(null);
 
     // 成功 / 失敗どちらでも dialog は閉じる

--- a/apps/fumufumu-frontend/vitest.setup.ts
+++ b/apps/fumufumu-frontend/vitest.setup.ts
@@ -21,11 +21,9 @@ vi.mock("next/navigation", () => ({
 // open 属性をトグルするだけの最小スタブを当てる。これにより testing-library
 // が dialog 内の element を accessibility tree から取り出せるようになる。
 // 個別 test で呼び出し回数を観測したい場合は vi.spyOn で上書きできる。
-if (typeof HTMLDialogElement !== "undefined") {
-  HTMLDialogElement.prototype.showModal = function () {
-    this.open = true;
-  };
-  HTMLDialogElement.prototype.close = function () {
-    this.open = false;
-  };
-}
+HTMLDialogElement.prototype.showModal = function () {
+  this.open = true;
+};
+HTMLDialogElement.prototype.close = function () {
+  this.open = false;
+};

--- a/apps/fumufumu-frontend/vitest.setup.ts
+++ b/apps/fumufumu-frontend/vitest.setup.ts
@@ -1,1 +1,18 @@
 import "@testing-library/jest-dom/vitest"; // カスタムマッチャーを有効化
+import { vi } from "vitest";
+
+// next/navigation の useRouter は AppRouter context が無いと invariant で死ぬため、
+// 全 unit test で安全に使えるよう no-op スタブで上書きする。
+// 個別テストで挙動を観測したい場合は vi.mocked(...) で上書きする。
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));

--- a/apps/fumufumu-frontend/vitest.setup.ts
+++ b/apps/fumufumu-frontend/vitest.setup.ts
@@ -16,3 +16,16 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/",
   useSearchParams: () => new URLSearchParams(),
 }));
+
+// jsdom は HTMLDialogElement.showModal / close を実装していないため、
+// open 属性をトグルするだけの最小スタブを当てる。これにより testing-library
+// が dialog 内の element を accessibility tree から取り出せるようになる。
+// 個別 test で呼び出し回数を観測したい場合は vi.spyOn で上書きできる。
+if (typeof HTMLDialogElement !== "undefined") {
+  HTMLDialogElement.prototype.showModal = function () {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function () {
+    this.open = false;
+  };
+}

--- a/docs/projects/08-admin-content-check-list-view.md
+++ b/docs/projects/08-admin-content-check-list-view.md
@@ -247,7 +247,8 @@ src/features/admin-content-check/
 
 - **詳細画面は作らない**: 一覧カードに title / body / author / created_at が既に出揃っており、別画面に遷移しても追加で見せる情報がない（§3.3）
 - **承認**: カード内 `[承認]` ボタン → `window.confirm("承認しますか？")` → POST → `toast.success("承認しました")` + `router.refresh()`
-  - 確認 dialog を挟む理由: 承認時は ADR 009 の `ctx.waitUntil()` で投稿者に **メールが飛ぶ** ため、誤操作の影響が大きい
+  - 確認 dialog を挟む理由: 承認は投稿を公開状態に遷移させる不可逆な操作 (撤回フローは現状未整備) で、誤クリックの影響が大きい
+  - 補足: ADR 009 §2 では承認 API 内 `ctx.waitUntil()` での自動メール送信を設計として掲げているが、現状の実装 (`consultation-content-check.service.ts`) は DB 更新のみで auto-send は未実装。`sendApproved` を呼ぶのは `POST /internal/notifications/resend` (Bearer token 付き internal API) 経由の手動 resend のみ
 - **却下**: カード内 `[却下]` ボタン → 理由入力モーダル → POST → `toast.success("却下しました")` + `router.refresh()`
   - 理由 textarea は **1〜500 文字** で client-side validation（backend validator と同条件、`apps/fumufumu-backend/src/validators/content-check.validator.ts`）
 - **二重送信防止**: 送信中はボタン `disabled`

--- a/docs/projects/08-admin-content-check-list-view.md
+++ b/docs/projects/08-admin-content-check-list-view.md
@@ -234,7 +234,67 @@ src/features/admin-content-check/
 
 ---
 
-## 10. 関連
+## 10. 承認 / 却下 UI（追記 / Phase 2）
+
+> 本ドキュメント Phase 1（§1-§9）の続編として、§8 #1 で「次の PR」と置いた承認 / 却下 UI を実装する。Phase 1 は merge 済み（PR #146）であり、本セクションは Phase 2 のスコープを定義する。
+
+### 10.1 スコープ
+
+- pending な相談 / アドバイスに対し、admin が **一覧画面のカード上で直接** 承認 / 却下できる
+- バックエンドへの変更なし（既存 API `POST /api/admin/content-check/.../:id/decision` を呼ぶだけ）
+
+### 10.2 UI 方針
+
+- **詳細画面は作らない**: 一覧カードに title / body / author / created_at が既に出揃っており、別画面に遷移しても追加で見せる情報がない（§3.3）
+- **承認**: カード内 `[承認]` ボタン → `window.confirm("承認しますか？")` → POST → `toast.success("承認しました")` + `router.refresh()`
+  - 確認 dialog を挟む理由: 承認時は ADR 009 の `ctx.waitUntil()` で投稿者に **メールが飛ぶ** ため、誤操作の影響が大きい
+- **却下**: カード内 `[却下]` ボタン → 理由入力モーダル → POST → `toast.success("却下しました")` + `router.refresh()`
+  - 理由 textarea は **1〜500 文字** で client-side validation（backend validator と同条件、`apps/fumufumu-backend/src/validators/content-check.validator.ts`）
+- **二重送信防止**: 送信中はボタン `disabled`
+- **同時操作（404）**: backend が "未処理の投稿チェックが見つかりません" を 404 で返した場合は `toast.error("他の管理者が既に処理した可能性があります")` + `router.refresh()`（リストから消える）
+
+### 10.3 実装方針
+
+- **mutation 経路**: 既存パターン踏襲で **Client から `apiClient` + `router.refresh()`**（Server Action は本リポジトリで初採用になり、本 PR と検証コストを混ぜない判断）
+- **CLAUDE.md 制約**: `useEffect` を使わず、すべて onClick / form handler / `useRef` で完結させる
+- **モーダル基盤**: native `<dialog>` + `showModal()` を採用。focus trap / ESC close が標準実装で、UI ライブラリ（shadcn / radix 等）を新規導入しない
+
+### 10.4 ファイル構成（追加）
+
+```
+src/features/admin-content-check/
+├── api/
+│   └── adminContentCheckDecisionApi.ts   # ★ 追加: client-side decision API wrapper
+├── components/
+│   ├── DecisionActions.tsx               # ★ 追加: [承認] [却下] ボタン群 (Client Component)
+│   └── RejectDialog.tsx                  # ★ 追加: 却下時の理由入力モーダル (Client Component)
+```
+
+`PendingItemCard` は既存の `meta` slot と同様に `actions?: React.ReactNode` slot を 1 つ増やすだけにとどめる。
+
+### 10.5 実装ステップ（コミット境界）
+
+1. **本コミット**: 本セクション追記（コードは変更しない）
+2. `adminContentCheckDecisionApi.ts` — `decideConsultationApi` / `decideAdviceApi` のみ実装、UI には繋がない
+3. `PendingItemCard` に `actions` slot を追加（既存呼び出しに影響なし）
+4. **承認 only** end-to-end — `DecisionActions` の承認パスと list 差し込み。ブラウザで承認が効く状態にする
+5. **却下** — `RejectDialog` と `DecisionActions` の却下パス追加。ブラウザで却下が効く状態にする
+6. vitest component tests を追加（`DecisionActions` / `RejectDialog`）
+7. typecheck / lint / test green
+
+### 10.6 権限
+
+ADR 010 §4 の `adminGuard` (backend) と `AdminLayout` (frontend) が既に効いているため、本 Phase では追加実装なし。
+
+### 10.7 本 Phase 2 で含めないこと
+
+- 却下理由（reason）の表示画面 / 履歴閲覧 — DB には保存されるが、運用上 DB 直見の前提のまま
+- 投稿者への却下通知 — 別途 ADR で議論
+- 楽観的更新（optimistic UI）— `router.refresh()` で十分軽快、Phase 1 と同じく "送信成功 → 再 fetch" にとどめる
+
+---
+
+## 11. 関連
 
 - ADR 007: [`docs/design/adr/007-content-check-mvp-operation-strategy.md`](../design/adr/007-content-check-mvp-operation-strategy.md) — content-check の DB 設計と運用方針
 - ADR 009: [`docs/design/adr/009-email-notification-delivery-strategy-mvp.md`](../design/adr/009-email-notification-delivery-strategy-mvp.md) — 承認時メール送信


### PR DESCRIPTION
## Summary

`/admin` の投稿チェック一覧 (Phase 1 / #146) に、**pending な相談 / アドバイスを admin が直接承認 / 却下できる UI** を追加する。backend 既存の decide endpoint (`POST /api/admin/content-check/.../:id/decision`) を呼ぶ frontend-only 変更。

`docs/projects/08-admin-content-check-list-view.md` §10 (Phase 2) の実装。

## 動作

| 操作 | フロー |
|---|---|
| 承認 | `[承認]` クリック → `window.confirm` → POST → toast「承認しました」+ list refresh |
| 却下 | `[却下]` クリック → reason 入力 modal (1〜500 文字) → POST → toast「却下しました」+ list refresh |
| 同時操作 (404) | toast「他の管理者が既に処理した可能性があります」+ list refresh で stale 行を消す |
| backend エラー (4xx/5xx) | toast「承認/却下に失敗しました」(list は保持、再試行可能) |
| network 障害 | toast「ネットワーク接続を確認してください」 |
| 二重送信防止 | 送信中はボタン / textarea を `disabled` |

## 主要な設計判断

- **詳細画面は作らない** — 一覧カードに title / body / author / created_at が出揃っており、操作のためだけに別画面に遷移するのは冗長 (§10.2)
- **承認に確認 dialog を挟む** — 承認は投稿を公開状態に遷移させる不可逆な操作で、撤回フローが現状未整備のため (§10.2)
  - ※ ADR 009 §2 は承認時の自動メール送信を「設計として」掲げているが、**現状の実装は DB 更新のみで auto-send は未実装** (`sendApproved` は `POST /internal/notifications/resend` 経由の手動 resend のみ)
- **mutation は Client から `apiClient` + `router.refresh()`** — 既存 `LoginForm` / `useConsultationConfirm` のパターン踏襲。Server Action は本リポジトリ初採用になるため、本 PR と検証コストを混ぜない判断 (§10.3)
- **モーダルは native `<dialog>` + `showModal()`** — UI ライブラリ (shadcn / radix 等) を新規導入せず、focus trap / ESC close を標準実装に任せる (§10.3)
- **`useId()` で per-instance な label / dialog id** — `RejectDialog` は pending item 数だけレンダーされるため、id をベタ書きにすると document 内で衝突し、label↔textarea のペアリングや `aria-labelledby` が壊れる
- **`kind` 分岐に exhaustive `never` check** — 将来 `kind` enum 拡張時に TypeScript で気付ける構造に
- **`RejectDialog.handleSubmit` に safety-net catch** — async 関数の throw が `<form onSubmit>` から unhandled rejection として leak するのを防ぐ。親 `DecisionActions.decide` が error を toast 化する責務を持つ契約

## ファイル構成

```
apps/fumufumu-frontend/src/features/admin-content-check/
├── api/
│   └── adminContentCheckDecisionApi.ts   ← 新規: client-side decision API wrapper
├── components/
│   ├── DecisionActions.tsx               ← 新規: [承認] [却下] ボタン群 (Client Component)
│   ├── DecisionActions.test.tsx          ← 新規: 12 cases
│   ├── RejectDialog.tsx                  ← 新規: 却下 reason 入力モーダル
│   ├── RejectDialog.test.tsx             ← 新規: 7 cases
│   ├── PendingItemCard.tsx               ← actions slot 追加
│   ├── PendingItemCard.test.tsx          ← actions slot 描画 test 追加
│   ├── PendingConsultationList.tsx       ← DecisionActions を配線
│   └── PendingAdviceList.tsx             ← DecisionActions を配線
docs/projects/
└── 08-admin-content-check-list-view.md   ← §10 Phase 2 セクション追記
apps/fumufumu-frontend/
└── vitest.setup.ts                       ← next/navigation mock + HTMLDialogElement stub
```

## 権限

ADR 010 §4 の `adminGuard` (backend) と `AdminLayout` (frontend) が既存で機能しており、本 PR では認可関連の追加実装なし。non-admin は本機能を発見できない (404)。

## 本 PR で意図的に含めないこと → follow-up issues

- **`content_checks.checked_by`** (誰が承認/却下したかの DB 永続化) → #148
- **構造化ログ** (decide 操作の application log) → #150
- **frontend test infra (`mockRouter` singleton 化)** (`router.refresh()` を assert 可能にする pattern) → #149
- **validation 定数 (`MAX_REASON_LENGTH` 等) の frontend/backend 共有化** → #147
- **却下理由の表示画面 / 履歴閲覧** (投稿者通知や rejected 履歴 UI) → 別 ADR / 別 PR

## Test Plan

- [x] vitest 37 cases all green (`pnpm test`)
- [x] biome lint clean (`pnpm lint`)
- [x] 承認: 確認 dialog → OK → list から行が消える / toast「承認しました」
- [x] 承認: 確認 dialog → Cancel → 何も起きない
- [x] 却下: modal 中央表示、ESC / 「閉じる」で dialog 終了
- [x] 却下: 空 / 空白のみ → inline error、reason 入力 → list から行が消える / toast「却下しました」
- [x] 同時操作: 別タブから 同 item を先に処理 → 後発で 404 toast + 自動 list 更新

## 関連

- 計画書: [`docs/projects/08-admin-content-check-list-view.md`](docs/projects/08-admin-content-check-list-view.md) (§10 Phase 2)
- ADR 007: 投稿チェック機能 MVP 運用
- ADR 009: 承認時メール送信戦略 (※ 現状 auto-send 未実装)
- ADR 010: /admin の権限制御
- Phase 1: #146
