### PR TITLE
🐛fix(advice): 相談詳細で投稿チェック未承認の助言を除外、投稿後 UX も pending 前提に整合

### DIFF
--- a/.github/workflows/be-health-check-ci.yml
+++ b/.github/workflows/be-health-check-ci.yml
@@ -70,9 +70,16 @@ jobs:
         jq "$JQ_FILTER" wrangler.jsonc > wrangler.tmp.jsonc && mv wrangler.tmp.jsonc wrangler.jsonc
         echo "D1 database binding (DB -> ${{ secrets.D1_DATABASE_ID }}) added to wrangler.jsonc for CI deployment."
 
-        # 2. Worker名に使用するブランチ名を整形（スラッシュをハイフンに置換）
+        # 2. Worker名に使用するブランチ名を整形（スラッシュをハイフンに置換し、54文字制限内に収める）
+        # Cloudflare Workers の preview 有効スクリプト名は最大 54 文字（code: 100315）
         BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-        WORKER_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')-ci-test
+        BRANCH_NORMALIZED=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+        SUFFIX="-ci-test"
+        MAX_BRANCH_LEN=$((54 - ${#SUFFIX}))
+        TRUNCATED_BRANCH="${BRANCH_NORMALIZED:0:$MAX_BRANCH_LEN}"
+        # truncate 結果の末尾ハイフンを除去（区切り重複を避けるため）
+        TRUNCATED_BRANCH="${TRUNCATED_BRANCH%-}"
+        WORKER_NAME="${TRUNCATED_BRANCH}${SUFFIX}"
 
         # 3. デプロイを実行（D1バインディング情報も同時に適用される）
         set +e
@@ -133,9 +140,14 @@ jobs:
       if: always() # 後のステップで失敗しても、必ず実行する 
       run: |
         set +e
-        # ステップ 2 で使用した Worker 名を再構築
+        # ステップ 2 で使用した Worker 名を再構築（同じ truncate ロジックを適用）
         BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-        WORKER_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')-ci-test
+        BRANCH_NORMALIZED=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+        SUFFIX="-ci-test"
+        MAX_BRANCH_LEN=$((54 - ${#SUFFIX}))
+        TRUNCATED_BRANCH="${BRANCH_NORMALIZED:0:$MAX_BRANCH_LEN}"
+        TRUNCATED_BRANCH="${TRUNCATED_BRANCH%-}"
+        WORKER_NAME="${TRUNCATED_BRANCH}${SUFFIX}"
               
         echo "Checking if Worker exists: $WORKER_NAME"
         

--- a/apps/fumufumu-backend/src/repositories/consultation.repository.ts
+++ b/apps/fumufumu-backend/src/repositories/consultation.repository.ts
@@ -131,6 +131,36 @@ export class ConsultationRepository {
 		) as SQL;
 	}
 
+	private buildAdvicePublicVisibilityCondition(): SQL {
+		const approvedCheckExists = exists(
+			this.db
+				.select({ id: contentChecks.id })
+				.from(contentChecks)
+				.where(
+					and(
+						eq(contentChecks.targetType, "advice"),
+						eq(contentChecks.targetId, advices.id),
+						eq(contentChecks.status, "approved"),
+					),
+				),
+		);
+
+		const noCheckExists = notExists(
+			this.db
+				.select({ id: contentChecks.id })
+				.from(contentChecks)
+				.where(
+					and(
+						eq(contentChecks.targetType, "advice"),
+						eq(contentChecks.targetId, advices.id),
+					),
+				),
+		);
+
+		// 既存データ(no-check)は表示を維持しつつ、check付きは approved のみ表示する
+		return or(approvedCheckExists, noCheckExists) as SQL;
+	}
+
 	/**
 	 * フィルタ条件からWHERE句を構築する（findAll / count 共通）
 	 */
@@ -172,6 +202,7 @@ export class ConsultationRepository {
 			eq(advices.consultationId, consultationId),
 			eq(advices.draft, false),
 			isNull(advices.hiddenAt),
+			this.buildAdvicePublicVisibilityCondition(),
 		];
 
 		if (filters?.userId !== undefined) {

--- a/apps/fumufumu-backend/src/test/consultations/advice-create.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/advice-create.test.ts
@@ -1,7 +1,13 @@
 import { env } from 'cloudflare:test';
 import { describe, it, expect, beforeAll } from 'vitest';
 import app from '../../index';
-import { setupIntegrationTest, forceSetHidden } from '../helpers/db-helper';
+import {
+  approveAdvice,
+  approveConsultation,
+  forceSetHidden,
+  rejectConsultation,
+  setupIntegrationTest,
+} from '../helpers/db-helper';
 import { createAndLoginUser } from '../helpers/auth-helper';
 import { createApiRequest } from '../helpers/request-helper';
 import { assertUnauthorizedError, assertValidationError } from '../helpers/assert-helper';
@@ -10,24 +16,6 @@ describe('Consultations API - Advice Create (POST /:id/advice)', () => {
   let user: Awaited<ReturnType<typeof createAndLoginUser>>;
   let consultationId: number;
   let tagId: number;
-  const approveConsultation = async (id: number) => {
-    await env.DB
-      .prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'consultation' AND target_id = ?")
-      .bind(id)
-      .run();
-  };
-  const rejectConsultation = async (id: number) => {
-    await env.DB
-      .prepare("UPDATE content_checks SET status = 'rejected', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'consultation' AND target_id = ?")
-      .bind(id)
-      .run();
-  };
-  const approveAdvice = async (id: number) => {
-    await env.DB
-      .prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
-      .bind(id)
-      .run();
-  };
 
   beforeAll(async () => {
     await setupIntegrationTest();

--- a/apps/fumufumu-backend/src/test/consultations/advice-create.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/advice-create.test.ts
@@ -22,6 +22,12 @@ describe('Consultations API - Advice Create (POST /:id/advice)', () => {
       .bind(id)
       .run();
   };
+  const approveAdvice = async (id: number) => {
+    await env.DB
+      .prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
+      .bind(id)
+      .run();
+  };
 
   beforeAll(async () => {
     await setupIntegrationTest();
@@ -68,7 +74,7 @@ describe('Consultations API - Advice Create (POST /:id/advice)', () => {
     expect(data.draft).toBe(false);
   });
 
-  it('アドバイス投稿後、親の相談詳細を取得するとアドバイスが含まれている', async () => {
+  it('アドバイス投稿 + approved 後、親の相談詳細にアドバイスが含まれる', async () => {
     const postReq = createApiRequest(`/api/consultations/${consultationId}/advice`, 'POST', {
       cookie: user.cookie,
       body: {
@@ -77,6 +83,8 @@ describe('Consultations API - Advice Create (POST /:id/advice)', () => {
     });
     const postRes = await app.fetch(postReq, env);
     expect(postRes.status).toBe(201);
+    const posted = await postRes.json() as any;
+    await approveAdvice(posted.id);
 
     const getReq = createApiRequest(`/api/consultations/${consultationId}`, 'GET', {
       cookie: user.cookie,

--- a/apps/fumufumu-backend/src/test/consultations/advice-list.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/advice-list.test.ts
@@ -1,7 +1,13 @@
 import { env } from 'cloudflare:test';
 import { beforeAll, describe, expect, it } from 'vitest';
 import app from '../../index';
-import { setupIntegrationTest } from '../helpers/db-helper';
+import {
+	approveAdvice,
+	approveConsultation,
+	rejectAdvice,
+	rejectConsultation,
+	setupIntegrationTest,
+} from '../helpers/db-helper';
 import { createAndLoginUser } from '../helpers/auth-helper';
 import { createApiRequest } from '../helpers/request-helper';
 import { assertUnauthorizedError, assertValidationError } from '../helpers/assert-helper';
@@ -15,30 +21,6 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 	let draftConsultationId: number;
 	let hiddenConsultationId: number;
 	let tagId: number;
-	const approveConsultation = async (consultationId: number) => {
-		await env.DB
-			.prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'consultation' AND target_id = ?")
-			.bind(consultationId)
-			.run();
-	};
-	const rejectConsultation = async (consultationId: number) => {
-		await env.DB
-			.prepare("UPDATE content_checks SET status = 'rejected', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'consultation' AND target_id = ?")
-			.bind(consultationId)
-			.run();
-	};
-	const approveAdvice = async (adviceId: number) => {
-		await env.DB
-			.prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
-			.bind(adviceId)
-			.run();
-	};
-	const rejectAdvice = async (adviceId: number) => {
-		await env.DB
-			.prepare("UPDATE content_checks SET status = 'rejected', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
-			.bind(adviceId)
-			.run();
-	};
 	const draftAdviceBody = '下書き回答（一覧非表示）のテストです。10文字以上あります。';
 	const hiddenAdviceBody = '非表示回答（一覧非表示）のテストです。10文字以上あります。';
 	const filterTargetPublicBodies = [

--- a/apps/fumufumu-backend/src/test/consultations/advice-list.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/advice-list.test.ts
@@ -27,6 +27,18 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 			.bind(consultationId)
 			.run();
 	};
+	const approveAdvice = async (adviceId: number) => {
+		await env.DB
+			.prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
+			.bind(adviceId)
+			.run();
+	};
+	const rejectAdvice = async (adviceId: number) => {
+		await env.DB
+			.prepare("UPDATE content_checks SET status = 'rejected', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
+			.bind(adviceId)
+			.run();
+	};
 	const draftAdviceBody = '下書き回答（一覧非表示）のテストです。10文字以上あります。';
 	const hiddenAdviceBody = '非表示回答（一覧非表示）のテストです。10文字以上あります。';
 	const filterTargetPublicBodies = [
@@ -82,6 +94,8 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 				},
 			}), env);
 			expect(adviceRes.status).toBe(201);
+			const advice = await adviceRes.json() as any;
+			await approveAdvice(advice.id);
 		}
 
 		const draftAdviceRes = await app.fetch(createApiRequest(`/api/consultations/${consultationId}/advice`, 'POST', {
@@ -102,6 +116,7 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 		}), env);
 		expect(hiddenAdviceRes.status).toBe(201);
 		const hiddenAdvice = await hiddenAdviceRes.json() as any;
+		await approveAdvice(hiddenAdvice.id);
 		await env.DB
 			.prepare("UPDATE advices SET hidden_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE id = ?")
 			.bind(hiddenAdvice.id)
@@ -161,6 +176,8 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 				},
 			}), env);
 			expect(adviceRes.status).toBe(201);
+			const advice = await adviceRes.json() as any;
+			await approveAdvice(advice.id);
 		}
 
 		const filterTargetDraftRes = await app.fetch(createApiRequest(`/api/consultations/${userIdFilterConsultationId}/advice`, 'POST', {
@@ -181,6 +198,7 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 		}), env);
 		expect(filterTargetHiddenRes.status).toBe(201);
 		const filterTargetHiddenAdvice = await filterTargetHiddenRes.json() as any;
+		await approveAdvice(filterTargetHiddenAdvice.id);
 		await env.DB
 			.prepare("UPDATE advices SET hidden_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE id = ?")
 			.bind(filterTargetHiddenAdvice.id)
@@ -195,6 +213,8 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 				},
 			}), env);
 			expect(adviceRes.status).toBe(201);
+			const advice = await adviceRes.json() as any;
+			await approveAdvice(advice.id);
 		}
 
 		const noPublicDraftRes = await app.fetch(createApiRequest(`/api/consultations/${userIdFilterConsultationId}/advice`, 'POST', {
@@ -215,6 +235,7 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 		}), env);
 		expect(noPublicHiddenRes.status).toBe(201);
 		const noPublicHiddenAdvice = await noPublicHiddenRes.json() as any;
+		await approveAdvice(noPublicHiddenAdvice.id);
 		await env.DB
 			.prepare("UPDATE advices SET hidden_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE id = ?")
 			.bind(noPublicHiddenAdvice.id)
@@ -524,5 +545,102 @@ describe('Consultations API - Advice List (GET /:id/advices)', () => {
 		const body = await res.json() as any;
 		expect(body.error).toBe('NotFoundError');
 		expect(body.message).toBe(`相談が見つかりません: id=${created.id}`);
+	});
+
+	describe('content_check による advice 可視性フィルタ', () => {
+		const approvedAdviceBody = 'approved な公開回答です。10文字以上あります。';
+		const pendingAdviceBody = 'pending な公開回答です。10文字以上あります。';
+		const rejectedAdviceBody = 'rejected な公開回答です。10文字以上あります。';
+		const pendingAttackerBody = 'attacker の pending 回答です。10文字以上あります。';
+		let visibilityConsultationId: number;
+
+		beforeAll(async () => {
+			const consultationRes = await app.fetch(createApiRequest('/api/consultations', 'POST', {
+				cookie: user.cookie,
+				body: {
+					title: 'advice 可視性検証用相談',
+					body: 'content_check による advice 可視性を検証する本文です。',
+					draft: false,
+					tagIds: [tagId],
+				},
+			}), env);
+			expect(consultationRes.status).toBe(201);
+			const consultation = await consultationRes.json() as any;
+			visibilityConsultationId = consultation.id;
+			await approveConsultation(visibilityConsultationId);
+
+			const approvedRes = await app.fetch(createApiRequest(`/api/consultations/${visibilityConsultationId}/advice`, 'POST', {
+				cookie: user.cookie,
+				body: { body: approvedAdviceBody, draft: false },
+			}), env);
+			expect(approvedRes.status).toBe(201);
+			await approveAdvice((await approvedRes.json() as any).id);
+
+			const pendingRes = await app.fetch(createApiRequest(`/api/consultations/${visibilityConsultationId}/advice`, 'POST', {
+				cookie: user.cookie,
+				body: { body: pendingAdviceBody, draft: false },
+			}), env);
+			expect(pendingRes.status).toBe(201);
+			// pending のまま放置
+
+			const rejectedRes = await app.fetch(createApiRequest(`/api/consultations/${visibilityConsultationId}/advice`, 'POST', {
+				cookie: user.cookie,
+				body: { body: rejectedAdviceBody, draft: false },
+			}), env);
+			expect(rejectedRes.status).toBe(201);
+			await rejectAdvice((await rejectedRes.json() as any).id);
+
+			const pendingAttackerRes = await app.fetch(createApiRequest(`/api/consultations/${visibilityConsultationId}/advice`, 'POST', {
+				cookie: attacker.cookie,
+				body: { body: pendingAttackerBody, draft: false },
+			}), env);
+			expect(pendingAttackerRes.status).toBe(201);
+		});
+
+		it('他者視点では approved な advice のみが一覧に含まれる', async () => {
+			const req = createApiRequest(`/api/consultations/${visibilityConsultationId}/advices`, 'GET', {
+				cookie: attacker.cookie,
+				queryParams: { limit: 100 },
+			});
+			const res = await app.fetch(req, env);
+			expect(res.status).toBe(200);
+			const body = await res.json() as any;
+			const bodies = body.data.map((a: any) => a.body);
+			expect(bodies).toContain(approvedAdviceBody);
+			expect(bodies).not.toContain(pendingAdviceBody);
+			expect(bodies).not.toContain(rejectedAdviceBody);
+			expect(bodies).not.toContain(pendingAttackerBody);
+			expect(body.pagination.total_items).toBe(1);
+		});
+
+		it('author 本人視点でも自分の pending / rejected advice は相談詳細の一覧に含まれない', async () => {
+			const req = createApiRequest(`/api/consultations/${visibilityConsultationId}/advices`, 'GET', {
+				cookie: user.cookie,
+				queryParams: { limit: 100 },
+			});
+			const res = await app.fetch(req, env);
+			expect(res.status).toBe(200);
+			const body = await res.json() as any;
+			const bodies = body.data.map((a: any) => a.body);
+			expect(bodies).toContain(approvedAdviceBody);
+			expect(bodies).not.toContain(pendingAdviceBody);
+			expect(bodies).not.toContain(rejectedAdviceBody);
+			expect(body.pagination.total_items).toBe(1);
+		});
+
+		it('GET /api/consultations/:id の advices にも同じ可視性フィルタが効く', async () => {
+			const req = createApiRequest(`/api/consultations/${visibilityConsultationId}`, 'GET', {
+				cookie: attacker.cookie,
+			});
+			const res = await app.fetch(req, env);
+			expect(res.status).toBe(200);
+			const body = await res.json() as any;
+			const advices = body.advices ?? [];
+			const bodies = advices.map((a: any) => a.body);
+			expect(bodies).toContain(approvedAdviceBody);
+			expect(bodies).not.toContain(pendingAdviceBody);
+			expect(bodies).not.toContain(rejectedAdviceBody);
+			expect(bodies).not.toContain(pendingAttackerBody);
+		});
 	});
 });

--- a/apps/fumufumu-backend/src/test/consultations/detail.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/detail.test.ts
@@ -1,7 +1,12 @@
 import { env } from 'cloudflare:test';
 import { describe, it, expect, beforeAll } from 'vitest';
 import app from '../../index';
-import { setupIntegrationTest, forceSetHidden } from '../helpers/db-helper';
+import {
+  approveAdvice,
+  approveConsultation,
+  forceSetHidden,
+  setupIntegrationTest,
+} from '../helpers/db-helper';
 import { createAndLoginUser } from '../helpers/auth-helper';
 import { createApiRequest } from '../helpers/request-helper';
 import { assertUnauthorizedError, assertValidationError } from '../helpers/assert-helper';
@@ -11,18 +16,6 @@ describe('Consultations API - Detail (GET /:id)', () => {
   let attacker: Awaited<ReturnType<typeof createAndLoginUser>>;
   let tagId: number;
   let existingId: number;
-  const approveConsultation = async (consultationId: number) => {
-    await env.DB
-      .prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'consultation' AND target_id = ?")
-      .bind(consultationId)
-      .run();
-  };
-  const approveAdvice = async (adviceId: number) => {
-    await env.DB
-      .prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
-      .bind(adviceId)
-      .run();
-  };
 
   const testBody = 'テスト本文です。10文字以上にします。';
 

--- a/apps/fumufumu-backend/src/test/consultations/detail.test.ts
+++ b/apps/fumufumu-backend/src/test/consultations/detail.test.ts
@@ -17,6 +17,12 @@ describe('Consultations API - Detail (GET /:id)', () => {
       .bind(consultationId)
       .run();
   };
+  const approveAdvice = async (adviceId: number) => {
+    await env.DB
+      .prepare("UPDATE content_checks SET status = 'approved', checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = 'advice' AND target_id = ?")
+      .bind(adviceId)
+      .run();
+  };
 
   const testBody = 'テスト本文です。10文字以上にします。';
 
@@ -111,6 +117,7 @@ describe('Consultations API - Detail (GET /:id)', () => {
     });
     const publicRes = await app.fetch(createPublicAdviceReq, env);
     expect(publicRes.status).toBe(201);
+    await approveAdvice((await publicRes.json() as any).id);
 
     const createDraftAdviceReq = createApiRequest(`/api/consultations/${existingId}/advice`, 'POST', {
       cookie: user.cookie,
@@ -294,6 +301,7 @@ describe('Consultations API - Detail (GET /:id)', () => {
         body: { body, draft: false },
       }), env);
       expect(adviceRes.status).toBe(201);
+      await approveAdvice((await adviceRes.json() as any).id);
     }
 
     const detailRes = await app.fetch(createApiRequest(`/api/consultations/${consultation.id}`, 'GET', {
@@ -339,6 +347,7 @@ describe('Consultations API - Detail (GET /:id)', () => {
         body: { body: `範囲外検証回答${i}: 10文字以上の本文です。`, draft: false },
       }), env);
       expect(adviceRes.status).toBe(201);
+      await approveAdvice((await adviceRes.json() as any).id);
     }
 
     const detailRes = await app.fetch(createApiRequest(`/api/consultations/${consultation.id}`, 'GET', {
@@ -398,6 +407,7 @@ describe('Consultations API - Detail (GET /:id)', () => {
       body: { body: visibleAdviceBody, draft: false },
     }), env);
     expect(visibleAdviceRes.status).toBe(201);
+    await approveAdvice((await visibleAdviceRes.json() as any).id);
 
     const hiddenAdviceRes = await app.fetch(createApiRequest(`/api/consultations/${consultation.id}/advice`, 'POST', {
       cookie: user.cookie,
@@ -405,6 +415,7 @@ describe('Consultations API - Detail (GET /:id)', () => {
     }), env);
     expect(hiddenAdviceRes.status).toBe(201);
     const hiddenAdvice = await hiddenAdviceRes.json() as any;
+    await approveAdvice(hiddenAdvice.id);
 
     await env.DB
       .prepare("UPDATE advices SET hidden_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE id = ?")
@@ -446,6 +457,7 @@ describe('Consultations API - Detail (GET /:id)', () => {
     }), env);
     expect(newerAdviceRes.status).toBe(201);
     const newerAdvice = await newerAdviceRes.json() as any;
+    await approveAdvice(newerAdvice.id);
 
     const olderAdviceRes = await app.fetch(createApiRequest(`/api/consultations/${consultation.id}/advice`, 'POST', {
       cookie: user.cookie,
@@ -453,6 +465,7 @@ describe('Consultations API - Detail (GET /:id)', () => {
     }), env);
     expect(olderAdviceRes.status).toBe(201);
     const olderAdvice = await olderAdviceRes.json() as any;
+    await approveAdvice(olderAdvice.id);
 
     const now = Date.now();
     const olderTs = now - 100000;

--- a/apps/fumufumu-backend/src/test/helpers/db-helper.ts
+++ b/apps/fumufumu-backend/src/test/helpers/db-helper.ts
@@ -88,3 +88,30 @@ export async function forceSetHidden(id: number) {
     "UPDATE consultations SET hidden_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE id = ?"
   ).bind(id).run();
 }
+
+const updateContentCheckStatusSql =
+  "UPDATE content_checks SET status = ?, checked_at = (cast(unixepoch('subsecond') * 1000 as integer)), updated_at = (cast(unixepoch('subsecond') * 1000 as integer)) WHERE target_type = ? AND target_id = ?";
+
+export async function approveConsultation(consultationId: number) {
+  await env.DB.prepare(updateContentCheckStatusSql)
+    .bind("approved", "consultation", consultationId)
+    .run();
+}
+
+export async function rejectConsultation(consultationId: number) {
+  await env.DB.prepare(updateContentCheckStatusSql)
+    .bind("rejected", "consultation", consultationId)
+    .run();
+}
+
+export async function approveAdvice(adviceId: number) {
+  await env.DB.prepare(updateContentCheckStatusSql)
+    .bind("approved", "advice", adviceId)
+    .run();
+}
+
+export async function rejectAdvice(adviceId: number) {
+  await env.DB.prepare(updateContentCheckStatusSql)
+    .bind("rejected", "advice", adviceId)
+    .run();
+}

--- a/apps/fumufumu-frontend/src/features/consultation/hooks/useAdviceConfirm.ts
+++ b/apps/fumufumu-frontend/src/features/consultation/hooks/useAdviceConfirm.ts
@@ -48,8 +48,8 @@ export const useAdviceConfirm = (consultationId: number) => {
 
       // 投稿直後は content_check が pending のため一般画面には表示されない。
       // ADR 007 の導線に従い、author 自身が投稿状況を確認できるプロフィールへ遷移する。
-      toast.success("投稿チェック中です。承認後に表示されます。");
-      router.push(ROUTES.USER);
+      toast.success("投稿しました。チェック完了後に表示されます。");
+      router.replace(ROUTES.USER);
     } catch (error) {
       console.error(error);
       toast.error("投稿に失敗しました。");

--- a/apps/fumufumu-frontend/src/features/consultation/hooks/useAdviceConfirm.ts
+++ b/apps/fumufumu-frontend/src/features/consultation/hooks/useAdviceConfirm.ts
@@ -46,8 +46,10 @@ export const useAdviceConfirm = (consultationId: number) => {
 
       reset();
 
-      toast.success("アドバイスを投稿しました！");
-      router.push(ROUTES.CONSULTATION.DETAIL(consultationId));
+      // 投稿直後は content_check が pending のため一般画面には表示されない。
+      // ADR 007 の導線に従い、author 自身が投稿状況を確認できるプロフィールへ遷移する。
+      toast.success("投稿チェック中です。承認後に表示されます。");
+      router.push(ROUTES.USER);
     } catch (error) {
       console.error(error);
       toast.error("投稿に失敗しました。");


### PR DESCRIPTION
## 概要

相談詳細の助言一覧で、content_check が pending / rejected な advice が表示されていた漏れを修正する。

`ConsultationRepository.buildAdviceWhereConditions` に visibility filter が欠けており、`GET /api/consultations/:id` と `GET /api/consultations/:id/advices` の両方で漏れていた。consultation 側は同等の filter が実装済みで、advice 側だけが対応漏れ (#112 のスコープ漏れ)。

合わせて投稿後の frontend UX も pending 前提に整合させる暫定対応を含む。

## 変更内容

### Backend
- content_check の `target_type=advice` 用 visibility helper を追加し、advice 取得 query に組み込む
- ADR 007 L171 通り、author 本人視点でも相談詳細の pending / rejected advice は非表示

### Frontend (暫定対応)
- advice 投稿成功時のトースト文言を「投稿しました。チェック完了後に表示されます。」に変更
- 遷移先を相談詳細 → プロフィール (`/user`) に変更し、ADR 007 L169-173 の投稿後導線に整合
- 上記遷移を `router.push` → `router.replace` に変え、ブラウザバックで空フォーム画面に戻らないようにする

### Test
- 既存 fixture を新仕様に追従 (advice 投稿後に approve するヘルパー利用)
- pending / rejected advice が相談詳細の助言一覧に出ないことの検証を追加 (他者視点 + author 本人視点 + `GET /api/consultations/:id` 経路)
- content_check 系の approve / reject ヘルパーを `db-helper` に集約

## 注意点 (UX の限界)

#111 で実装予定の「プロフィールのアドバイス一覧 + 投稿チェック中バッジ」が未実装のため、投稿後プロフィールに遷移しても「アドバイス」タブは "準備中" 表示のままになる。

**#111 完了までは、author が自分の pending advice を画面で確認する場所が無い一時状態**となる。本 PR ではトースト文言で「投稿チェック中」状態を伝える暫定対応のみ。

## スコープ外

- consultation 側の同種 UX 修正 (投稿後の文言・遷移先) → #155
- プロフィールでのアドバイス一覧 + 審査中バッジ表示 → #111 (API 追加が必要)

## 関連 issue

- Parent: #110
- 元 issue (Closed, 漏れの補完): #112
- Frontend 本体: #111

## 派生 issue (本 PR 作業中に発見)

- filter 呼び忘れの再発防止 (biome rule): #153
- 「advice 消えた」運用ランブック: #154
- backend の typecheck コマンド追加: #152

## テスト

- backend: 16 ファイル / 171 テスト all green
- frontend: biome lint pass, 6 ファイル / 37 テスト all green