### PR TITLE
🐛fix(ci): preview Worker 名を 54 文字以内に切り詰める

### DIFF
--- a/.github/workflows/be-health-check-ci.yml
+++ b/.github/workflows/be-health-check-ci.yml
@@ -70,9 +70,16 @@ jobs:
         jq "$JQ_FILTER" wrangler.jsonc > wrangler.tmp.jsonc && mv wrangler.tmp.jsonc wrangler.jsonc
         echo "D1 database binding (DB -> ${{ secrets.D1_DATABASE_ID }}) added to wrangler.jsonc for CI deployment."
 
-        # 2. Worker名に使用するブランチ名を整形（スラッシュをハイフンに置換）
+        # 2. Worker名に使用するブランチ名を整形（スラッシュをハイフンに置換し、54文字制限内に収める）
+        # Cloudflare Workers の preview 有効スクリプト名は最大 54 文字（code: 100315）
         BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-        WORKER_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')-ci-test
+        BRANCH_NORMALIZED=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+        SUFFIX="-ci-test"
+        MAX_BRANCH_LEN=$((54 - ${#SUFFIX}))
+        TRUNCATED_BRANCH="${BRANCH_NORMALIZED:0:$MAX_BRANCH_LEN}"
+        # truncate 結果の末尾ハイフンを除去（区切り重複を避けるため）
+        TRUNCATED_BRANCH="${TRUNCATED_BRANCH%-}"
+        WORKER_NAME="${TRUNCATED_BRANCH}${SUFFIX}"
 
         # 3. デプロイを実行（D1バインディング情報も同時に適用される）
         set +e
@@ -133,9 +140,14 @@ jobs:
       if: always() # 後のステップで失敗しても、必ず実行する 
       run: |
         set +e
-        # ステップ 2 で使用した Worker 名を再構築
+        # ステップ 2 で使用した Worker 名を再構築（同じ truncate ロジックを適用）
         BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-        WORKER_NAME=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')-ci-test
+        BRANCH_NORMALIZED=$(echo "$BRANCH_NAME" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+        SUFFIX="-ci-test"
+        MAX_BRANCH_LEN=$((54 - ${#SUFFIX}))
+        TRUNCATED_BRANCH="${BRANCH_NORMALIZED:0:$MAX_BRANCH_LEN}"
+        TRUNCATED_BRANCH="${TRUNCATED_BRANCH%-}"
+        WORKER_NAME="${TRUNCATED_BRANCH}${SUFFIX}"
               
         echo "Checking if Worker exists: $WORKER_NAME"
         


### PR DESCRIPTION
## 概要
[fix/advice-pending-visibility-on-consultation-detail](https://github.com/team-devlab/fumufumu/pull/XXX) の CI が `be-health-check-ci` の preview deploy ステップで失敗した:

```
Script name is too long to be used with previews enabled.
Script names with previews enabled cannot be longer than 54 characters. [code: 100315]
```

ブランチ名 (52 字) + `-ci-test` (8 字) = 60 字で Cloudflare 制限 54 字を超過していた。

## 変更内容
`apps/.github/workflows/be-health-check-ci.yml` の WORKER_NAME 生成箇所 (deploy / cleanup 両方) で、ブランチ名側を 46 字に truncate し末尾ハイフンを除去してから `-ci-test` を付与するように変更。

## 注意
`pull_request` トリガーは `branches: [main, master]` 限定のため、**本 PR (base = 親ブランチ) では CI が走らず、truncate ロジックの動作検証はマージ後の親 PR で確認**する形になる。ロジック自体はローカルの bash で複数ブランチ名パターンを検証済み。

## ローカル検証結果
| branch | worker name | length |
|---|---|---|
| `fix/advice-pending-visibility-on-consultation-detail` | `fix-advice-pending-visibility-on-consultation-ci-test` | 53 |
| `main` | `main-ci-test` | 12 |
| `chore/ci-preview-worker-name-cap` | `chore-ci-preview-worker-name-cap-ci-test` | 40 |

## base
`fix/advice-pending-visibility-on-consultation-detail` (stacked PR)